### PR TITLE
feat: implement endpoint for registering user

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,7 +1,7 @@
 # Flask app setup - configurations, extensions, blueprint registration, etc
 from flask import Flask
 from flask_cors import CORS
-from app.models.animal import db
+from app.models import db
 
 def create_app():
     app = Flask(__name__)
@@ -17,8 +17,13 @@ def create_app():
     
     # Register blueprints
     from app.routes.animal_routes import animal_bp
+    from app.routes.auth_routes import auth_bp
     app.register_blueprint(animal_bp, url_prefix='/api/animals')
-    
+    app.register_blueprint(auth_bp, url_prefix='/api/auth')
+
+    # Import all models so db.create_all() picks them up
+    from app.models import animal, user  # noqa: F401
+
     # Create tables if they dont exist
     with app.app_context():
         db.create_all()

--- a/backend/app/controllers/auth_controller.py
+++ b/backend/app/controllers/auth_controller.py
@@ -1,0 +1,21 @@
+# Auth controller - business logic for authentication
+from app.models import db
+from app.models.user import User
+from werkzeug.security import generate_password_hash
+
+
+def register_user(name, password):
+    """
+    Register a new user.
+    Returns (user_dict, None) on success or (None, error_message) on failure.
+    """
+    existing_user = User.query.filter_by(name=name).first()
+    if existing_user:
+        return None, "Username already exists"
+
+    password_hash = generate_password_hash(password)
+    user = User(name=name, password_hash=password_hash)
+    db.session.add(user)
+    db.session.commit()
+
+    return user.to_dict(), None

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,1 +1,4 @@
-# Models package
+# Models package — shared db instance
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()

--- a/backend/app/models/animal.py
+++ b/backend/app/models/animal.py
@@ -1,8 +1,7 @@
 # Animal model
-from flask_sqlalchemy import SQLAlchemy
+from app.models import db
 from datetime import datetime
 
-db = SQLAlchemy()
 
 class Animal(db.Model):
     __tablename__ = 'animals'

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,25 @@
+# User model
+from app.models import db
+from datetime import datetime
+
+
+class User(db.Model):
+    __tablename__ = 'users'
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    name = db.Column(db.Text, unique=True, nullable=False)
+    password_hash = db.Column(db.Text, nullable=False)
+    role = db.Column(db.Text, default='user')
+    donation_points = db.Column(db.Integer, default=0)
+    volunteer_points = db.Column(db.Integer, default=0)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'role': self.role,
+            'donation_points': self.donation_points,
+            'volunteer_points': self.volunteer_points,
+            'created_at': self.created_at.isoformat() if self.created_at else None
+        }

--- a/backend/app/routes/auth_routes.py
+++ b/backend/app/routes/auth_routes.py
@@ -1,0 +1,21 @@
+# Auth routes - Flask blueprint defining API endpoints for /api/auth
+from flask import Blueprint, jsonify, request
+from app.controllers import auth_controller
+
+auth_bp = Blueprint('auth', __name__)
+
+
+@auth_bp.route('/register', methods=['POST'])
+def register():
+    # POST /api/auth/register - register a new user
+    data = request.get_json()
+
+    if not data or not data.get('name') or not data.get('password'):
+        return jsonify({'error': 'Name and password are required'}), 400
+
+    user, error = auth_controller.register_user(data['name'], data['password'])
+
+    if error:
+        return jsonify({'error': error}), 409
+
+    return jsonify(user), 201


### PR DESCRIPTION
Main changes:

- Move shared `db` instance to `models` package instead of `models.animals`
- Add user model, also omit email from schema, as I decided maybe it's not needed for now
- Implement auth controller and routes

Testing results:
```fish
# requests / responses
aurimasr@fedora ~/R/k674-gyvunu-prieglaudos-sistema (main)> curl -v -X POST http://localhost:8081/api/auth/register \
                                                                    -H "Content-Type: application/json" \
                                                                    -d '{"name": "onlyname"}'
{
  "error": "Name and password are required"
}

aurimasr@fedora ~/R/k674-gyvunu-prieglaudos-sistema (main)> curl -X POST http://localhost:8081/api/auth/register \
                                                                    -H "Content-Type: application/json" \
                                                                    -d '{"name": "testuser", "password": "mypassword"}'
{
  "created_at": "2026-02-23T15:56:13.406905",
  "donation_points": 0,
  "id": 1,
  "name": "testuser",
  "role": "user",
  "volunteer_points": 0
}
aurimasr@fedora ~/R/k674-gyvunu-prieglaudos-sistema (main)> curl -X POST http://localhost:8081/api/auth/register \
                                                                    -H "Content-Type: application/json" \
                                                                    -d '{"name": "testuser", "password": "mypassword"}'
{
  "error": "Username already exists"
}

# server logs
127.0.0.1 - - [23/Feb/2026 17:56:10] "POST /api/auth/register HTTP/1.1" 400 -
127.0.0.1 - - [23/Feb/2026 17:56:13] "POST /api/auth/register HTTP/1.1" 201 -
127.0.0.1 - - [23/Feb/2026 17:56:46] "POST /api/auth/register HTTP/1.1" 409 -
```

Related:
https://github.com/s7eamy/k674-gyvunu-prieglaudos-sistema/issues/33