### PR TITLE
feat/filter-animals-endpoint

### DIFF
--- a/backend/app/controllers/animal_controller.py
+++ b/backend/app/controllers/animal_controller.py
@@ -1,6 +1,7 @@
 # Animal controller - business logic for animal CRUD operations
 from app.models.animal import Animal
 from datetime import datetime,  timedelta
+from flask import abort
 
 def get_animals(args):
     """
@@ -8,11 +9,11 @@ def get_animals(args):
     Get all animals from db if no filters selected
     Returns list of animal dictionaries
     """
-    # By which paramters animal entries can be filtered by
+    # By which parameters animal entries can be filtered by
     # created_at is not here because it needs special actions
     regular_filters = {
         'id', 'name', 'type', 'breed', 'size', 'age', 
-        'vaccinated', 'temperament', 'description', 
+        'vaccinated', 'tem  perament', 'description', 
         'adopted'
     }
 
@@ -29,22 +30,7 @@ def get_animals(args):
 
             query = query.filter(Animal.created_at >= start_date, Animal.created_at < end_date)
         except ValueError:
-            pass
+            abort(400, description="Invalid date format, use YYYY-MM-DD")
     
     animals = query.all()
     return [animal.to_dict() for animal in animals]
-
-"""
-Deprecated by method above
-
-def get_animal_by_id(animal_id):
-    
-    Get a single animal by ID
-    Returns animal dictionary or None if not found
-    
-    animal = Animal.query.get(animal_id)
-    return animal.to_dict() if animal else None
-
-"""
-
-

--- a/backend/app/routes/animal_routes.py
+++ b/backend/app/routes/animal_routes.py
@@ -9,28 +9,3 @@ def get_animals():
     # get list of animals based on arguments in args
     animals_list = animal_controller.get_animals(request.args)
     return jsonify({"animals": animals_list}), 200
-
-"""
-Methods bellow not needed? All animals can be returned with empty query
-
-Returns animal with selected id (/api/animals/1 returns animal with id=1)
-
-@animal_bp.route('/<int:animal_id>', methods=['GET'])
-def get_animal(animal_id):
-    # GET /api/animals/<id> - get a single animal by ID
-    animal = animal_controller.get_animal_by_id(animal_id)
-    
-    if animal is None:
-        return jsonify({'error': 'Animal not found'}), 404
-    
-    return jsonify(animal), 200
-
- Returns all animals form table 
-
-@animal_bp.route('', methods=['GET'])
-def get_animals():
-    # GET /api/animals - get all animals
-    animals_list = animal_controller.get_all_animals()
-    return jsonify({"animals": animals_list}), 200
-
-"""


### PR DESCRIPTION
Can now filter with query strings. Eg: http://localhost:8081/api/animals?adopted=0&age=12&created_at=2026-02-27&type=cat

In comments are the previously used GET methods, that can be replaced with the new filter method since selecting no filters returns all animal entries. Might be useful later idk.

Closes #25 
Related to #2 