### PR TITLE
feat: implement volunteering levels

### DIFF
--- a/backend/app/controllers/volunteer_registration_controller.py
+++ b/backend/app/controllers/volunteer_registration_controller.py
@@ -2,14 +2,48 @@
 from app.models.volunteer_registration import Volunteer_Registration
 from app.models import db
 
+# Thresholds: level n requires 2^n - 1 completed volunteerings
+LEVEL_THRESHOLDS = [0, 1, 3, 7, 15, 31]
+MAX_LEVEL = len(LEVEL_THRESHOLDS) - 1  # 5
+
+
+def _calculate_level(completed_count):
+    """Calculate volunteer level based on completed volunteering count."""
+    level = 0
+    for i, threshold in enumerate(LEVEL_THRESHOLDS):
+        if completed_count >= threshold:
+            level = i
+        else:
+            break
+    return level
+
 
 def get_volunteer_registrations(user_id):
     """
     Get all volunteer registrations that belong to user
     """
     registrations = Volunteer_Registration.query.filter_by(user_id=user_id).all()
-    
+
     return [registration.to_dict() for registration in registrations]
+
+
+def get_volunteer_level(user_id):
+    """
+    Calculate volunteer level based on number of attended registrations.
+    """
+    completed_count = Volunteer_Registration.query.filter_by(
+        user_id=user_id, attended=1
+    ).count()
+
+    level = _calculate_level(completed_count)
+    next_threshold = LEVEL_THRESHOLDS[level + 1] if level < MAX_LEVEL else None
+
+    return {
+        "level": level,
+        "max_level": MAX_LEVEL,
+        "completed_count": completed_count,
+        "next_threshold": next_threshold,
+    }
 
 def create_volunteer_registration(user_id, date, time_from, time_to):
     """

--- a/backend/app/routes/volunteer_registration_routes.py
+++ b/backend/app/routes/volunteer_registration_routes.py
@@ -10,10 +10,15 @@ volunteer_registration_bp = Blueprint('volunteerRegistrations', __name__)
 @jwt_required()
 def get_volunteer_registrations():
     user_id = get_jwt_identity()
-    print(user_id)
-    # get list of volunteer registrations
     registrations = volunteer_registration_controller.get_volunteer_registrations(user_id)
     return jsonify({"volunteerRegistrations": registrations}), 200
+
+@volunteer_registration_bp.route('/volunteer/level', methods=['GET'])
+@jwt_required()
+def get_volunteer_level():
+    user_id = get_jwt_identity()
+    level_info = volunteer_registration_controller.get_volunteer_level(user_id)
+    return jsonify({"volunteerLevel": level_info}), 200
 
 @volunteer_registration_bp.route('/volunteer', methods=['POST'])
 @jwt_required()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -59,7 +59,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1434,7 +1433,6 @@
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1445,7 +1443,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1505,7 +1502,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -1757,7 +1753,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1880,7 +1875,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2208,7 +2202,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3058,7 +3051,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3126,7 +3118,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3136,7 +3127,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3377,7 +3367,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3464,7 +3453,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3586,7 +3574,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/common/VolunteerLevelCard.css
+++ b/frontend/src/components/common/VolunteerLevelCard.css
@@ -1,0 +1,54 @@
+.volunteer-level {
+  padding: 1.25rem 1.5rem;
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.volunteer-level__info {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.volunteer-level__badge {
+  display: inline-block;
+  padding: 0.3rem 0.9rem;
+  border-radius: 20px;
+  background: var(--color-terracotta);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.volunteer-level__completed {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.volunteer-level__bar-container {
+  display: flex;
+  gap: 6px;
+}
+
+.volunteer-level__bar-segment {
+  flex: 1;
+  height: 10px;
+  border-radius: 5px;
+  background: var(--color-border);
+  transition: background 300ms ease;
+}
+
+.volunteer-level__bar-segment--filled {
+  background: var(--color-terracotta);
+}
+
+.volunteer-level__next {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}

--- a/frontend/src/components/common/VolunteerLevelCard.tsx
+++ b/frontend/src/components/common/VolunteerLevelCard.tsx
@@ -1,0 +1,36 @@
+import type { VolunteerLevel } from '../../types/VolunteerLevel';
+import './VolunteerLevelCard.css';
+
+type VolunteerLevelCardProps = {
+  volunteerLevel: VolunteerLevel;
+};
+
+function VolunteerLevelCard({ volunteerLevel }: VolunteerLevelCardProps) {
+  return (
+    <div className="volunteer-level">
+      <div className="volunteer-level__info">
+        <span className="volunteer-level__badge">Level {volunteerLevel.level}</span>
+        <span className="volunteer-level__completed">
+          {volunteerLevel.completed_count} volunteering{volunteerLevel.completed_count !== 1 ? 's' : ''} completed
+        </span>
+      </div>
+      <div className="volunteer-level__bar-container">
+        {Array.from({ length: volunteerLevel.max_level }, (_, i) => (
+          <div
+            key={i}
+            className={`volunteer-level__bar-segment ${i < volunteerLevel.level ? 'volunteer-level__bar-segment--filled' : ''}`}
+          />
+        ))}
+      </div>
+      {volunteerLevel.next_threshold !== null ? (
+        <p className="volunteer-level__next">
+          Next level at {volunteerLevel.next_threshold} completed volunteerings
+        </p>
+      ) : (
+        <p className="volunteer-level__next">Max level reached!</p>
+      )}
+    </div>
+  );
+}
+
+export default VolunteerLevelCard;

--- a/frontend/src/pages/Volunteer/VolunteerRegistrationsPage.tsx
+++ b/frontend/src/pages/Volunteer/VolunteerRegistrationsPage.tsx
@@ -1,8 +1,10 @@
 // Volunteer page — users can sign up for a volunteering spot
 import { useState, useEffect } from 'react';
-import { getAll, createRegistration } from '../../services/volunteerRegistrationService';
+import { getAll, getLevel, createRegistration } from '../../services/volunteerRegistrationService';
 import type { VolunteerRegistration } from '../../types/VolunteerRegistration';
+import type { VolunteerLevel } from '../../types/VolunteerLevel';
 import Navbar from '../../components/layout/Navbar';
+import VolunteerLevelCard from '../../components/common/VolunteerLevelCard';
 import VolunteerRegistrationCard from '../../components/common/VolunteerRegistrationCard';
 import VolunteerRegistrationModal from '../../components/common/VolunteerRegistrationModal';
 import './VolunteerRegistrationspage.css';
@@ -16,6 +18,7 @@ export default function VolunteerRegistrationsPage() {
   const tomorrowString = tomorrowObj.toISOString().split('T')[0];
 
   const [volunteerRegistrations, setVolunteerRegistrations] = useState<VolunteerRegistration[]>([]);
+  const [volunteerLevel, setVolunteerLevel] = useState<VolunteerLevel | null>(null);
   const [selectedVolunteerRegistration, setSelectedVolunteerRegistration] = useState<VolunteerRegistration | null>(null);
   const [LoggedIn, setLoggedIn] = useState(true);
   const [selectedDate, setSelectedDate] = useState<string>(tomorrowString);
@@ -47,8 +50,9 @@ export default function VolunteerRegistrationsPage() {
   useEffect(() => {
     const fetchVolunteerRegistrations = async () => {
       try {
-        const data = await getAll();
-        setVolunteerRegistrations(data);
+        const [registrations, level] = await Promise.all([getAll(), getLevel()]);
+        setVolunteerRegistrations(registrations);
+        setVolunteerLevel(level);
       } catch (error) {
         if(error instanceof Error && error.message === "NOT_LOGGED_IN"){
           setLoggedIn(false);
@@ -66,8 +70,9 @@ export default function VolunteerRegistrationsPage() {
   
     await createRegistration(selectedDate, time_from, time_to);
 
-    const data = await getAll();
-    setVolunteerRegistrations(data);
+    const [registrations, level] = await Promise.all([getAll(), getLevel()]);
+    setVolunteerRegistrations(registrations);
+    setVolunteerLevel(level);
 
   } catch (error) {
     console.error("Registration creation failed", error);
@@ -88,6 +93,9 @@ export default function VolunteerRegistrationsPage() {
           
           {LoggedIn && (
             <>
+            {volunteerLevel && (
+              <VolunteerLevelCard volunteerLevel={volunteerLevel} />
+            )}
             <p>Found {volunteerRegistrations.length} of your registrations</p>
           </>
         )}

--- a/frontend/src/services/volunteerRegistrationService.ts
+++ b/frontend/src/services/volunteerRegistrationService.ts
@@ -1,20 +1,33 @@
-// VolunteerRegistration service — API calls for animal CRUD (getAll, getById, create, update, delete)
+// VolunteerRegistration service — API calls for volunteer registration CRUD
 import api from './api';
 import axios from 'axios';
 import type { VolunteerRegistration } from '../types/VolunteerRegistration';
-
+import type { VolunteerLevel } from '../types/VolunteerLevel';
 
 export const getAll = async (): Promise<VolunteerRegistration[]> => {
   try {
     const response = await api.get<{ volunteerRegistrations: VolunteerRegistration[] }>("/api/volunteer", {});
     return response.data.volunteerRegistrations;
-  } catch (error: unknown) { 
+  } catch (error: unknown) {
     if (axios.isAxiosError(error)) {
       if (error.response?.status === 401) {
         throw new Error("NOT_LOGGED_IN");
       }
     }
-    // Re-throw the original error if it's not a 401
+    throw error;
+  }
+};
+
+export const getLevel = async (): Promise<VolunteerLevel> => {
+  try {
+    const response = await api.get<{ volunteerLevel: VolunteerLevel }>("/api/volunteer/level", {});
+    return response.data.volunteerLevel;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) {
+        throw new Error("NOT_LOGGED_IN");
+      }
+    }
     throw error;
   }
 };

--- a/frontend/src/types/VolunteerLevel.ts
+++ b/frontend/src/types/VolunteerLevel.ts
@@ -1,0 +1,6 @@
+export interface VolunteerLevel {
+    level: number;
+    max_level: number;
+    completed_count: number;
+    next_threshold: number | null;
+}


### PR DESCRIPTION
- Added volunteer levels (0-5) with exponential thresholds (2^n - 1), calculated from attended registrations via a new `GET /api/volunteer/level` endpoint.
- Frontend displays a `VolunteerLevelCard` component on the volunteering page showing current level badge, progress bar, and next threshold.
- Type definition in `types/VolunteerLevel.ts`, `HTTP 401` handling in the service, and component extraction into `components/common/` all follow existing project conventions.

Related:
closes https://github.com/s7eamy/k674-gyvunu-prieglaudos-sistema/issues/9

Example:
<img width="1960" height="1777" alt="image" src="https://github.com/user-attachments/assets/5cfd1429-dc27-4d18-ac7e-7523dd5cdd94" />
