### PR TITLE
feat: donations with stripe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Backend
+FLASK_SECRET_KEY=your-flask-secret-key-here
+JWT_SECRET_KEY=your-jwt-secret-key-here
+DATABASE_URL=sqlite:///app.db
+FRONTEND_URL=http://localhost:5173
+STRIPE_SECRET_KEY=sk_test_key
+STRIPE_CURRENCY=eur
+
+# Frontend
+VITE_API_URL=http://localhost:8081
+VITE_STRIPE_PUBLISHABLE_KEY=pk_test_publishable_key

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,5 +1,9 @@
 # Flask app setup - configurations, extensions, blueprint registration, etc
 from datetime import timedelta
+from pathlib import Path
+import os
+
+from dotenv import load_dotenv
 from flask import Flask
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
@@ -7,16 +11,21 @@ from app.models import db
 
 jwt = JWTManager()
 
+load_dotenv(Path(__file__).resolve().parents[2] / '.env')
+
 def create_app():
     app = Flask(__name__)
 
     # Configuration
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///shelter.db'
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL', 'sqlite:///shelter.db')
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    app.config['SECRET_KEY'] = 'dev-secret-key' # Change later for production
-    app.config['JWT_SECRET_KEY'] = 'dev-jwt-secret-key' # Change later for production
+    app.config['SECRET_KEY'] = os.getenv('FLASK_SECRET_KEY', 'dev-secret-key')
+    app.config['JWT_SECRET_KEY'] = os.getenv('JWT_SECRET_KEY', 'dev-jwt-secret-key')
     app.config['JWT_ACCESS_TOKEN_EXPIRES'] = timedelta(hours=1)
     app.config['JWT_TOKEN_LOCATION'] = ['headers', 'query_string']
+    app.config['FRONTEND_URL'] = os.getenv('FRONTEND_URL', 'http://localhost:5173')
+    app.config['STRIPE_SECRET_KEY'] = os.getenv('STRIPE_SECRET_KEY', '')
+    app.config['STRIPE_CURRENCY'] = os.getenv('STRIPE_CURRENCY', 'eur')
 
     # Initialize extensions
     db.init_app(app)
@@ -41,11 +50,13 @@ def create_app():
     app.register_blueprint(volunteer_registration_bp, url_prefix='/api')
     from app.routes.admin_routes import admin_registration_bp
     app.register_blueprint(admin_registration_bp, url_prefix='/api')
+    from app.routes.donation_routes import donation_bp
+    app.register_blueprint(donation_bp, url_prefix='/api/donations')
     from app.routes.merchandise_routes import merchandise_bp
     app.register_blueprint(merchandise_bp, url_prefix='/api/merchandise')
 
     # Import all models so db.create_all() picks them up
-    from app.models import animal, user, volunteer_registration, merchandise # noqa: F401
+    from app.models import animal, donation, user, volunteer_registration, merchandise # noqa: F401
 
     # Create tables if they dont exist
     with app.app_context():

--- a/backend/app/controllers/donation_controller.py
+++ b/backend/app/controllers/donation_controller.py
@@ -1,0 +1,182 @@
+from datetime import datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+
+import stripe
+from flask import abort, current_app
+
+from app.models import db
+from app.models.donation import Donation
+from app.models.user import User
+
+
+DONOR_LEVEL_THRESHOLDS = [0, 100, 250, 500, 1000]
+
+
+def _set_stripe_key():
+    stripe.api_key = current_app.config.get('STRIPE_SECRET_KEY', '')
+    if not stripe.api_key:
+        abort(500, description='Stripe is not configured')
+
+
+def _amount_to_cents(amount):
+    try:
+        amount_decimal = Decimal(str(amount))
+    except (InvalidOperation, TypeError, ValueError):
+        abort(400, description='A valid donation amount is required')
+
+    amount_cents = int((amount_decimal * Decimal('100')).quantize(Decimal('1'), rounding=ROUND_HALF_UP))
+    if amount_cents <= 0:
+        abort(400, description='Donation amount must be greater than zero')
+
+    return amount_cents
+
+
+def _build_donor_level(total_points):
+    max_level = len(DONOR_LEVEL_THRESHOLDS)
+    level = 1
+
+    for index in range(len(DONOR_LEVEL_THRESHOLDS) - 1, -1, -1):
+        if total_points >= DONOR_LEVEL_THRESHOLDS[index]:
+            level = index + 1
+            break
+
+    if level >= max_level:
+        return {
+            'level': max_level,
+            'max_level': max_level,
+            'total_points': total_points,
+            'points_to_next_level': 0,
+            'next_threshold': None,
+        }
+
+    next_threshold = DONOR_LEVEL_THRESHOLDS[level]
+    return {
+        'level': level,
+        'max_level': max_level,
+        'total_points': total_points,
+        'points_to_next_level': max(0, next_threshold - total_points),
+        'next_threshold': next_threshold,
+    }
+
+
+def get_donor_level(user_id):
+    user = User.query.get(user_id) if user_id else None
+    total_points = user.donation_points if user else 0
+    return _build_donor_level(total_points)
+
+
+def create_donation_payment_intent(data, user_id=None):
+    _set_stripe_key()
+
+    amount_cents = _amount_to_cents(data.get('amount'))
+    donor_name = (data.get('donorName') or '').strip()
+    donor_email = (data.get('donorEmail') or '').strip()
+    message = (data.get('message') or '').strip() or None
+    is_anonymous = bool(data.get('isAnonymous', False))
+
+    if is_anonymous:
+        donor_name = donor_name or 'Anonymous'
+        donor_email = None
+    else:
+        if not donor_name:
+            abort(400, description='Donor name is required')
+        if not donor_email:
+            abort(400, description='Donor email is required')
+
+    donation = Donation(
+        user_id=user_id,
+        donor_name=donor_name,
+        donor_email=donor_email,
+        message=message,
+        amount_cents=amount_cents,
+        currency=current_app.config.get('STRIPE_CURRENCY', 'eur'),
+        is_anonymous=is_anonymous,
+        payment_status='requires_payment_method',
+    )
+
+    db.session.add(donation)
+    db.session.flush()
+
+    try:
+        payment_intent = stripe.PaymentIntent.create(
+            amount=amount_cents,
+            currency=donation.currency,
+            automatic_payment_methods={'enabled': True},
+            receipt_email=donor_email,
+            description='Animal shelter donation',
+            metadata={
+                'donation_id': str(donation.id),
+                'user_id': str(user_id or ''),
+                'donor_name': donor_name,
+                'is_anonymous': 'true' if is_anonymous else 'false',
+            },
+        )
+    except stripe.error.StripeError as error:
+        db.session.rollback()
+        abort(502, description=f"Stripe payment intent could not be created: {error.user_message or str(error)}")
+
+    donation.stripe_payment_intent_id = payment_intent.id
+    donation.payment_status = payment_intent.status
+
+    db.session.commit()
+
+    return {
+        'donation': donation.to_dict(),
+        'client_secret': payment_intent.client_secret,
+    }
+
+
+def _mark_donation_succeeded(payment_intent):
+    donation = Donation.query.filter_by(stripe_payment_intent_id=payment_intent.id).first()
+    if not donation:
+        donation_id = payment_intent.metadata.get('donation_id')
+        if donation_id:
+            donation = Donation.query.get(int(donation_id))
+
+    if not donation or donation.payment_status == 'succeeded':
+        return
+
+    donation.payment_status = 'succeeded'
+    donation.paid_at = datetime.utcnow()
+
+    points_awarded = donation.amount_cents // 100
+    donation.points_awarded = points_awarded
+
+    if donation.user_id and points_awarded > 0:
+        user = User.query.get(donation.user_id)
+        if user:
+            user.donation_points = (user.donation_points or 0) + points_awarded
+
+    db.session.commit()
+
+
+def finalize_donation_payment(payment_intent_id, user_id=None):
+    _set_stripe_key()
+
+    if not payment_intent_id:
+        abort(400, description='paymentIntentId is required')
+
+    try:
+        payment_intent = stripe.PaymentIntent.retrieve(payment_intent_id)
+    except stripe.error.StripeError as error:
+        abort(502, description=f"Stripe payment intent retrieval failed: {error.user_message or str(error)}")
+
+    donation = Donation.query.filter_by(stripe_payment_intent_id=payment_intent.id).first()
+    if not donation:
+        abort(404, description='Donation was not found for this payment intent')
+
+    if donation.user_id and user_id and donation.user_id != user_id:
+        abort(403, description='You are not allowed to finalize this donation')
+
+    if payment_intent.status != 'succeeded':
+        abort(400, description=f"Payment is not completed yet (status: {payment_intent.status})")
+
+    _mark_donation_succeeded(payment_intent)
+
+    refreshed_donation = Donation.query.get(donation.id)
+    donor_level = get_donor_level(refreshed_donation.user_id) if refreshed_donation.user_id else None
+
+    return {
+        'donation': refreshed_donation.to_dict(),
+        'donor_level': donor_level,
+    }

--- a/backend/app/models/donation.py
+++ b/backend/app/models/donation.py
@@ -1,0 +1,42 @@
+# Donation model for Stripe-backed shelter donations
+from datetime import datetime
+
+from app.models import db
+
+
+class Donation(db.Model):
+    __tablename__ = 'donations'
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=True)
+    donor_name = db.Column(db.Text, nullable=False)
+    donor_email = db.Column(db.Text, nullable=True)
+    message = db.Column(db.Text, nullable=True)
+    amount_cents = db.Column(db.Integer, nullable=False)
+    currency = db.Column(db.Text, nullable=False, default='eur')
+    is_anonymous = db.Column(db.Boolean, default=False)
+    points_awarded = db.Column(db.Integer, default=0)
+    payment_status = db.Column(db.Text, default='requires_payment_method')
+    stripe_payment_intent_id = db.Column(db.Text, unique=True, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    paid_at = db.Column(db.DateTime, nullable=True)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'user_id': self.user_id,
+            'donor_name': self.donor_name,
+            'donor_email': self.donor_email,
+            'message': self.message,
+            'amount_cents': self.amount_cents,
+            'amount': round(self.amount_cents / 100, 2),
+            'currency': self.currency,
+            'is_anonymous': self.is_anonymous,
+            'points_awarded': self.points_awarded,
+            'payment_status': self.payment_status,
+            'stripe_payment_intent_id': self.stripe_payment_intent_id,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'paid_at': self.paid_at.isoformat() if self.paid_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/app/routes/donation_routes.py
+++ b/backend/app/routes/donation_routes.py
@@ -1,0 +1,37 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from app.controllers.donation_controller import (
+    create_donation_payment_intent,
+    finalize_donation_payment,
+    get_donor_level,
+)
+
+donation_bp = Blueprint('donation', __name__)
+
+
+@donation_bp.route('/level', methods=['GET'])
+@jwt_required(optional=True)
+def get_donor_level_route():
+    user_id = get_jwt_identity()
+    donor_level = get_donor_level(int(user_id)) if user_id else get_donor_level(None)
+    return jsonify({'donor_level': donor_level}), 200
+
+
+@donation_bp.route('/payment-intents', methods=['POST'])
+@jwt_required(optional=True)
+def create_donation_payment_intent_route():
+    data = request.get_json() or {}
+    user_id = get_jwt_identity()
+    result = create_donation_payment_intent(data, user_id=int(user_id) if user_id else None)
+    return jsonify(result), 201
+
+
+@donation_bp.route('/finalize', methods=['POST'])
+@jwt_required(optional=True)
+def finalize_donation_payment_route():
+    data = request.get_json() or {}
+    user_id = get_jwt_identity()
+    payment_intent_id = (data.get('paymentIntentId') or '').strip()
+    result = finalize_donation_payment(payment_intent_id, user_id=int(user_id) if user_id else None)
+    return jsonify(result), 200

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,5 @@ Flask-SQLAlchemy==3.1.1
 Flask-CORS==4.0.0
 Flask-Migrate==4.0.5
 Flask-JWT-Extended==4.7.1
+python-dotenv>=1.0.1,<2.0.0
+stripe>=11.0.0,<13.0.0

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@stripe/react-stripe-js": "^3.0.0",
+        "@stripe/stripe-js": "^4.0.0",
         "axios": "^1.13.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -59,6 +61,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1368,6 +1371,30 @@
         "win32"
       ]
     },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.10.0.tgz",
+      "integrity": "sha512-UPqHZwMwDzGSax0ZI7XlxR3tZSpgIiZdk3CiwjbTK978phwR/fFXeAXQcN/h8wTAjR4ZIAzdlI9DbOqJhuJdeg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-4.10.0.tgz",
+      "integrity": "sha512-KrMOL+sH69htCIXCaZ4JluJ35bchuCCznyPyrbN8JXSGQfwBI1SuIEMZNwvy8L8ykj29t6sa5BAAiL7fNoLZ8A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.16"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1433,6 +1460,7 @@
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1443,6 +1471,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1502,6 +1531,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -1779,6 +1809,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1901,6 +1932,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2228,6 +2260,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2778,7 +2811,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2888,6 +2920,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2980,6 +3024,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3077,6 +3130,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3123,6 +3177,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3144,6 +3209,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3153,12 +3219,19 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -3393,6 +3466,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3479,6 +3553,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3600,6 +3675,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@stripe/react-stripe-js": "^3.0.0",
+    "@stripe/stripe-js": "^4.0.0",
     "axios": "^1.13.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/components/common/DonationConfirmationModal.tsx
+++ b/frontend/src/components/common/DonationConfirmationModal.tsx
@@ -14,12 +14,14 @@ export default function DonationConfirmationModal({
   donation,
   onClose,
 }: DonationConfirmationModalProps) {
+  const donorName = donation.donorName || 'Anonymous';
+
   return (
     <div className="modal-overlay">
       <div className="donation-confirmation-modal">
         <div className="donation-confirmation__header">
           <h2>🎉 Thank You!</h2>
-          <p>Your donation has been received</p>
+          <p>Your donation was processed successfully</p>
         </div>
 
         <div className="donation-confirmation__content">
@@ -31,12 +33,14 @@ export default function DonationConfirmationModal({
           <div className="donation-confirmation__details">
             <div className="detail-row">
               <span className="detail-label">Name:</span>
-              <span className="detail-value">{donation.donorName}</span>
+              <span className="detail-value">{donorName}</span>
             </div>
-            <div className="detail-row">
-              <span className="detail-label">Email:</span>
-              <span className="detail-value">{donation.donorEmail}</span>
-            </div>
+            {donation.donorEmail && (
+              <div className="detail-row">
+                <span className="detail-label">Email:</span>
+                <span className="detail-value">{donation.donorEmail}</span>
+              </div>
+            )}
             {donation.pointsAwarded && (
               <div className="detail-row">
                 <span className="detail-label">Points Earned:</span>
@@ -52,9 +56,13 @@ export default function DonationConfirmationModal({
           </div>
 
           <div className="donation-confirmation__message">
-            <p>
-              A confirmation email has been sent to <strong>{donation.donorEmail}</strong>
-            </p>
+            {donation.donorEmail ? (
+              <p>
+                We captured the receipt email <strong>{donation.donorEmail}</strong> for this donation.
+              </p>
+            ) : (
+              <p>This donation was submitted anonymously.</p>
+            )}
             <p>
               Thank you for your support! Your donation will directly help us care for animals
               in our shelter.

--- a/frontend/src/pages/Donation/DonationPage.css
+++ b/frontend/src/pages/Donation/DonationPage.css
@@ -229,6 +229,23 @@
   min-height: 100px;
 }
 
+.donation-page__card-element {
+  border-radius: 10px;
+  border: 1.5px solid var(--color-border);
+  background: #fff;
+  transition: border-color 0.2s;
+}
+
+.donation-page__card-element .StripeElement {
+  padding: 12px 14px;
+}
+
+.donation-page__card-element:focus-within {
+  outline: none;
+  border-color: var(--color-terracotta);
+  box-shadow: 0 0 0 3px rgba(232, 114, 42, 0.1);
+}
+
 /* Impact section */
 .donation-page__impact {
   padding: 20px;

--- a/frontend/src/pages/Donation/DonationPage.tsx
+++ b/frontend/src/pages/Donation/DonationPage.tsx
@@ -1,49 +1,70 @@
 // Donation page — users can make donations to support the shelter
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState, type ChangeEvent } from 'react';
+import { CardElement, Elements, useElements, useStripe } from '@stripe/react-stripe-js';
+import { loadStripe } from '@stripe/stripe-js';
 import Navbar from '../../components/layout/Navbar';
 import DonationConfirmationModal from '../../components/common/DonationConfirmationModal';
 import DonorLevelCard from '../../components/common/DonorLevelCard';
-import { getDonorLevel } from '../../services/donorService';
+import { createDonationPaymentIntent, finalizeDonationPayment, getDonorLevel } from '../../services/donorService';
 import type { DonorLevel } from '../../types/DonorLevel';
 import './DonationPage.css';
 
 const PREDEFINED_AMOUNTS = [5, 10, 20, 50, 100];
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const stripePublishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY;
+const stripePromise = stripePublishableKey ? loadStripe(stripePublishableKey) : null;
 
-export default function DonationPage() {
+type DonationFormState = {
+  donorName: string;
+  donorEmail: string;
+  message: string;
+};
+
+type DonationPreview = {
+  amount: number;
+  donorName: string;
+  donorEmail: string;
+  message: string;
+  pointsAwarded: number;
+};
+
+function DonationPageContent() {
+  const stripe = useStripe();
+  const elements = useElements();
+
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null);
   const [customAmount, setCustomAmount] = useState('');
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [donorLevel, setDonorLevel] = useState<DonorLevel | null>(null);
   const [isLoggedIn] = useState(Boolean(localStorage.getItem('access_token')));
-  const [donationData, setDonationData] = useState<{
-    amount: number;
-    donorName: string;
-    donorEmail: string;
-    message: string;
-    pointsAwarded?: number;
-  } | null>(null);
-
+  const [donationData, setDonationData] = useState<DonationPreview | null>(null);
   const [isAnonymous, setIsAnonymous] = useState(false);
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<DonationFormState>({
     donorName: '',
     donorEmail: '',
     message: '',
   });
+  const [paymentError, setPaymentError] = useState('');
+  const [pageError, setPageError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const fetchDonorLevel = useCallback(async () => {
+    if (!isLoggedIn) {
+      return;
+    }
+
+    try {
+      const level = await getDonorLevel();
+      setDonorLevel(level);
+    } catch (error) {
+      console.error('Failed to fetch donor level', error);
+    }
+  }, [isLoggedIn]);
 
   // Fetch donor level on mount
   useEffect(() => {
-    const fetchDonorLevel = async () => {
-      if (isLoggedIn) {
-        try {
-          const level = await getDonorLevel();
-          setDonorLevel(level);
-        } catch (error) {
-          console.error('Failed to fetch donor level', error);
-        }
-      }
-    };
-    fetchDonorLevel();
-  }, [isLoggedIn]);
+    void fetchDonorLevel();
+  }, [fetchDonorLevel]);
 
   const handlePredefinedAmount = (amount: number) => {
     setSelectedAmount(amount);
@@ -55,9 +76,7 @@ export default function DonationPage() {
     setSelectedAmount(null);
   };
 
-  const handleInputChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
     setFormData((prev) => ({
       ...prev,
@@ -65,42 +84,7 @@ export default function DonationPage() {
     }));
   };
 
-  const handleDonate = () => {
-    const amount = selectedAmount || parseFloat(customAmount);
-
-    if (!amount || amount <= 0) {
-      alert('Please select or enter a valid donation amount');
-      return;
-    }
-
-    if (!isAnonymous) {
-      if (!formData.donorName.trim()) {
-        alert('Please enter your name');
-        return;
-      }
-
-      if (!formData.donorEmail.trim()) {
-        alert('Please enter your email');
-        return;
-      }
-    }
-
-    // Process donation (for now, just show confirmation)
-    const pointsAwarded = Math.floor(amount); // 1 point per €1
-    
-    setDonationData({
-      amount,
-      donorName: isAnonymous ? 'Anonymous' : formData.donorName,
-      donorEmail: isAnonymous ? '' : formData.donorEmail,
-      message: formData.message,
-      pointsAwarded,
-    });
-
-    setShowConfirmation(true);
-  };
-
-  const handleConfirmation = async () => {
-    // Reset form
+  const resetDonationForm = () => {
     setSelectedAmount(null);
     setCustomAmount('');
     setFormData({
@@ -108,39 +92,136 @@ export default function DonationPage() {
       donorEmail: '',
       message: '',
     });
-    setShowConfirmation(false);
-    setDonationData(null);
+    setIsAnonymous(false);
+    setPaymentError('');
+    setPageError('');
+  };
 
-    // Update donor level locally (simulate donation points being added)
-    if (isLoggedIn && donorLevel && donationData) {
-      const pointsAwarded = donationData.pointsAwarded || 0;
-      const newTotalPoints = donorLevel.total_points + pointsAwarded;
-      
-      // Calculate new level based on points
-      const levelThresholds = [0, 100, 250, 500, 1000]; // Cumulative thresholds for levels 1-5
-      let newLevel = 1;
-      for (let i = levelThresholds.length - 1; i >= 0; i--) {
-        if (newTotalPoints >= levelThresholds[i]) {
-          newLevel = i + 1;
-          break;
-        }
+  const handleDonate = async () => {
+    const amount = selectedAmount || parseFloat(customAmount);
+
+    if (!amount || amount <= 0) {
+      setPageError('Please select or enter a valid donation amount.');
+      return;
+    }
+
+    if (!isAnonymous) {
+      if (!formData.donorName.trim()) {
+        setPageError('Please enter your name.');
+        return;
       }
-      
-      const nextThreshold = levelThresholds[Math.min(newLevel, 4)] + (levelThresholds[Math.min(newLevel, 4)] === 0 ? 100 : 150);
-      const pointsToNextLevel = Math.max(0, nextThreshold - newTotalPoints);
-      
-      // Update the donor level state with new values
-      setDonorLevel({
-        level: newLevel,
-        max_level: 5,
-        total_points: newTotalPoints,
-        points_to_next_level: pointsToNextLevel,
-        next_threshold: pointsToNextLevel > 0 ? nextThreshold : 0,
+
+      if (!formData.donorEmail.trim()) {
+        setPageError('Please enter your email.');
+        return;
+      }
+
+      if (!EMAIL_PATTERN.test(formData.donorEmail.trim())) {
+        setPageError('Please enter a valid email address.');
+        return;
+      }
+    }
+
+    if (!stripe || !elements) {
+      setPageError('Stripe is still loading. Please try again in a moment.');
+      return;
+    }
+
+    const cardElement = elements.getElement(CardElement);
+    if (!cardElement) {
+      setPageError('Payment form is not ready yet.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setPaymentError('');
+    setPageError('');
+
+    try {
+      const response = await createDonationPaymentIntent({
+        amount,
+        donorName: isAnonymous ? 'Anonymous' : formData.donorName.trim(),
+        donorEmail: isAnonymous ? '' : formData.donorEmail.trim(),
+        message: formData.message.trim(),
+        isAnonymous,
       });
+
+      const { error, paymentIntent } = await stripe.confirmCardPayment(response.client_secret, {
+        payment_method: {
+          card: cardElement,
+          billing_details: {
+            name: isAnonymous ? 'Anonymous donor' : formData.donorName.trim(),
+            email: isAnonymous ? undefined : formData.donorEmail.trim(),
+          },
+        },
+      });
+
+      if (error) {
+        setPaymentError(error.message || 'Payment failed.');
+        return;
+      }
+
+      if (paymentIntent?.status === 'succeeded') {
+        if (!paymentIntent.id) {
+          setPaymentError('Payment succeeded, but confirmation ID is missing.');
+          return;
+        }
+
+        const finalizedDonation = await finalizeDonationPayment(paymentIntent.id);
+        const pointsAwarded = finalizedDonation.donation.points_awarded;
+
+        if (isLoggedIn && finalizedDonation.donor_level) {
+          setDonorLevel(finalizedDonation.donor_level);
+        }
+
+        setDonationData({
+          amount,
+          donorName: isAnonymous ? 'Anonymous' : formData.donorName.trim(),
+          donorEmail: isAnonymous ? '' : formData.donorEmail.trim(),
+          message: formData.message.trim(),
+          pointsAwarded,
+        });
+        setShowConfirmation(true);
+        return;
+      }
+
+      setPaymentError(`Payment completed with unexpected status: ${paymentIntent?.status || 'unknown'}.`);
+    } catch (error) {
+      console.error('Donation payment failed', error);
+      setPaymentError('Unable to start the donation payment. Please try again.');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
+  const handleConfirmation = () => {
+    setShowConfirmation(false);
+    setDonationData(null);
+    resetDonationForm();
+  };
+
   const totalAmount = selectedAmount || parseFloat(customAmount) || 0;
+
+  const cardElementOptions = {
+    hidePostalCode: true,
+    disableLink: true,
+    style: {
+      base: {
+        color: '#2c1a0e',
+        fontFamily: 'inherit',
+        fontSize: '16px',
+        fontSmoothing: 'antialiased',
+        iconColor: '#8a7060',
+        '::placeholder': {
+          color: '#8a7060',
+        },
+      },
+      invalid: {
+        color: '#b91c1c',
+        iconColor: '#b91c1c',
+      },
+    },
+  };
 
   return (
     <>
@@ -155,18 +236,15 @@ export default function DonationPage() {
         </div>
 
         <div className="donation-page__container">
-          {/* Left: Amount Selection */}
           <div className="donation-page__section">
             <h2>Step 1: Choose Your Donation Amount</h2>
 
-            {/* Predefined amounts */}
             <div className="donation-amounts">
               {PREDEFINED_AMOUNTS.map((amount) => (
                 <button
                   key={amount}
-                  className={`amount-button ${
-                    selectedAmount === amount ? 'amount-button--active' : ''
-                  }`}
+                  type="button"
+                  className={`amount-button ${selectedAmount === amount ? 'amount-button--active' : ''}`}
                   onClick={() => handlePredefinedAmount(amount)}
                 >
                   €{amount}
@@ -178,7 +256,6 @@ export default function DonationPage() {
               <span>or</span>
             </div>
 
-            {/* Custom amount */}
             <div className="donation-page__custom">
               <label htmlFor="custom-amount">Enter a custom amount (€)</label>
               <input
@@ -192,7 +269,6 @@ export default function DonationPage() {
               />
             </div>
 
-            {/* Donor Level Progress Bar */}
             {isLoggedIn && donorLevel && (
               <div className="donation-page__donor-level">
                 <DonorLevelCard donorLevel={donorLevel} />
@@ -205,7 +281,6 @@ export default function DonationPage() {
               </div>
             )}
 
-            {/* Display selected amount */}
             {totalAmount > 0 && (
               <div className="donation-page__selected">
                 <span>Selected amount:</span>
@@ -246,11 +321,9 @@ export default function DonationPage() {
                 </div>
               </>
             ) : (
-              <>
-                <div className="donation-page__anonymous-info">
-                  <p>You're donating <strong>anonymously</strong></p>
-                </div>
-              </>
+              <div className="donation-page__anonymous-info">
+                <p>You're donating <strong>anonymously</strong>.</p>
+              </div>
             )}
 
             <div className="donation-page__form-group">
@@ -265,8 +338,16 @@ export default function DonationPage() {
               />
             </div>
 
+            <div className="donation-page__form-group">
+              <label htmlFor="card-element">Card Details *</label>
+              <div className="donation-page__card-element">
+                <CardElement id="card-element" options={cardElementOptions} />
+              </div>
+            </div>
+
             {!isAnonymous ? (
               <button
+                type="button"
                 className="donation-page__anonymous-btn"
                 onClick={() => setIsAnonymous(true)}
               >
@@ -274,6 +355,7 @@ export default function DonationPage() {
               </button>
             ) : (
               <button
+                type="button"
                 className="donation-page__anonymous-btn donation-page__anonymous-btn--active"
                 onClick={() => setIsAnonymous(false)}
               >
@@ -293,27 +375,50 @@ export default function DonationPage() {
               </ul>
             </div>
 
-            {/* CTA Button */}
+            {pageError && <div className="donation-page__error">{pageError}</div>}
+            {paymentError && <div className="donation-page__error">{paymentError}</div>}
+
             <button
+              type="button"
               className="donation-page__cta"
               onClick={handleDonate}
-              disabled={totalAmount <= 0}
+              disabled={totalAmount <= 0 || isSubmitting || !stripe || !elements}
             >
-              {totalAmount > 0
-                ? `Donate €${totalAmount.toFixed(2)}`
-                : 'Select an amount to proceed'}
+              {isSubmitting
+                ? 'Processing payment...'
+                : totalAmount > 0
+                  ? `Donate €${totalAmount.toFixed(2)}`
+                  : 'Select an amount to proceed'}
             </button>
           </div>
         </div>
       </div>
 
-      {/* Confirmation Modal */}
       {showConfirmation && donationData && (
-        <DonationConfirmationModal
-          donation={donationData}
-          onClose={handleConfirmation}
-        />
+        <DonationConfirmationModal donation={donationData} onClose={handleConfirmation} />
       )}
     </>
+  );
+}
+
+export default function DonationPage() {
+  if (!stripePublishableKey) {
+    return (
+      <>
+        <Navbar />
+        <div className="donation-page">
+          <div className="donation-page__header">
+            <h1>💝 Support Our Shelter</h1>
+            <p>Stripe is not configured yet. Set VITE_STRIPE_PUBLISHABLE_KEY in the frontend env file.</p>
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <Elements stripe={stripePromise}>
+      <DonationPageContent />
+    </Elements>
   );
 }

--- a/frontend/src/services/donorService.ts
+++ b/frontend/src/services/donorService.ts
@@ -1,59 +1,20 @@
-import axios from 'axios';
+import api from './api';
 import type { DonorLevel } from '../types/DonorLevel';
+import type { CreateDonationPaymentIntentRequest, DonationFinalizeResponse, DonationPaymentIntentResponse } from '../types/Donation';
 
-const API_BASE_URL = 'http://localhost:5000/api';
-
-// Get donor level for current user
 export const getDonorLevel = async (): Promise<DonorLevel> => {
-  try {
-    const response = await axios.get(`${API_BASE_URL}/donors/level`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('access_token')}`,
-      },
-    });
-    return response.data;
-  } catch {
-    // For now, return default level if not logged in or API not available
-    return {
-      level: 1,
-      max_level: 5,
-      total_points: 0,
-      points_to_next_level: 100,
-      next_threshold: 100,
-    };
-  }
+  const response = await api.get<{ donor_level: DonorLevel }>('/api/donations/level');
+  return response.data.donor_level;
 };
 
-// Create a donation and award points
-export const createDonation = async (
-  amount: number,
-  donorName: string,
-  donorEmail: string,
-  message: string
-): Promise<{ success: boolean; pointsAwarded: number; newLevel: number }> => {
-  try {
-    const response = await axios.post(
-      `${API_BASE_URL}/donations/create`,
-      {
-        amount,
-        donor_name: donorName,
-        donor_email: donorEmail,
-        message,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem('access_token')}`,
-        },
-      }
-    );
-    return response.data;
-  } catch {
-    // Fallback: calculate points locally for demo
-    const pointsAwarded = Math.floor(amount);
-    return {
-      success: true,
-      pointsAwarded,
-      newLevel: 1,
-    };
-  }
+export const createDonationPaymentIntent = async (
+  donationData: CreateDonationPaymentIntentRequest
+): Promise<DonationPaymentIntentResponse> => {
+  const response = await api.post<DonationPaymentIntentResponse>('/api/donations/payment-intents', donationData);
+  return response.data;
+};
+
+export const finalizeDonationPayment = async (paymentIntentId: string): Promise<DonationFinalizeResponse> => {
+  const response = await api.post<DonationFinalizeResponse>('/api/donations/finalize', { paymentIntentId });
+  return response.data;
 };

--- a/frontend/src/types/Donation.ts
+++ b/frontend/src/types/Donation.ts
@@ -1,0 +1,45 @@
+export interface Donation {
+  id: number;
+  user_id: number | null;
+  donor_name: string;
+  donor_email: string | null;
+  message: string | null;
+  amount_cents: number;
+  amount: number;
+  currency: string;
+  is_anonymous: boolean;
+  points_awarded: number;
+  payment_status: string;
+  stripe_payment_intent_id: string | null;
+  created_at: string;
+  paid_at: string | null;
+  updated_at: string | null;
+}
+
+export interface CreateDonationPaymentIntentRequest {
+  amount: number;
+  donorName: string;
+  donorEmail: string;
+  message: string;
+  isAnonymous: boolean;
+}
+
+export interface DonationPaymentIntentResponse {
+  donation: Donation;
+  client_secret: string;
+}
+
+export interface DonationFinalizeRequest {
+  paymentIntentId: string;
+}
+
+export interface DonationFinalizeResponse {
+  donation: Donation;
+  donor_level: {
+    level: number;
+    max_level: number;
+    total_points: number;
+    points_to_next_level: number;
+    next_threshold: number | null;
+  } | null;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { resolve } from 'node:path'
 
 // https://vite.dev/config/
 export default defineConfig({
+  envDir: resolve(__dirname, '..'),
   plugins: [react()],
 })


### PR DESCRIPTION
Stripe donation flow (create intent -> confirm card -> finalize payment), env variables

only implemented for donations, without webhooks, config is now env-based

- Stripe donation payment flow
- backend donation model/controller/routes
- donation payment intent creation + explicit finalize API
- frontend donation page uses Stripe Elements/CardElement
- frontend flow calls backend finalize after successful card confirmation
- env configuration at root
- points awarded and saved in finalize

for testing use card 4242 4242 4242 with any future date and any cvc