### PR TITLE
feat/add-animal-images

### DIFF
--- a/backend/app/controllers/animal_controller.py
+++ b/backend/app/controllers/animal_controller.py
@@ -1,8 +1,16 @@
 # Animal controller - business logic for animal CRUD operations
 from app.models import db
-from app.models.animal import Animal
+from app.models.animal import Animal, AnimalImage
 from datetime import datetime,  timedelta
 from flask import abort
+from werkzeug.utils import secure_filename
+import os
+from pathlib import Path
+
+current_file = Path(__file__).resolve()
+project_root = current_file.parents[3] # location of k674 folder
+
+UPLOAD_FOLDER = project_root / 'frontend' / 'public' / 'images' / 'animals'
 
 def get_animals(args):
     """
@@ -50,7 +58,7 @@ def get_animals(args):
     return [animal.to_dict() for animal in animals]
 
 
-def add_animal(data):
+def add_animal(data, files):
     """
     Add a new animal to the system.
     Required fields: name, type, breed, size, age, vaccinated, temperament
@@ -93,7 +101,26 @@ def add_animal(data):
     )
     
     try:
+        os.makedirs(UPLOAD_FOLDER, exist_ok=True)
         db.session.add(animal)
+        db.session.flush() # allows to get animal id?
+
+        #adding images
+        if 'images' in files:
+            uploaded_files = files.getlist('images')
+            for file in uploaded_files:
+                if file and file.filename != '':
+                    
+                    filename = secure_filename(file.filename)
+                    unique_filename = f"{animal.id}_{filename}"
+                    file.save(os.path.join(UPLOAD_FOLDER, unique_filename))
+                    
+                    new_image = AnimalImage(
+                        animal_id=animal.id,
+                        url=f"/images/animals/{unique_filename}"
+                    )
+                    db.session.add(new_image)
+
         db.session.commit()
         return animal.to_dict(), None
     except Exception as e:

--- a/backend/app/models/animal.py
+++ b/backend/app/models/animal.py
@@ -17,7 +17,8 @@ class Animal(db.Model):
     description = db.Column(db.Text)
     adopted = db.Column(db.Integer, default=0)  # 0 = available, 1 = adopted
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    
+    images = db.relationship('AnimalImage', backref='animal', cascade="all, delete-orphan")
+
     def to_dict(self):
         # Convert model instance to dict for JSON
         return {
@@ -31,5 +32,20 @@ class Animal(db.Model):
             'temperament': self.temperament,
             'description': self.description,
             'adopted': bool(self.adopted),
-            'created_at': self.created_at.isoformat() if self.created_at else None
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            "images": [image.to_dict() for image in self.images]
+        }
+
+class AnimalImage(db.Model):
+    __tablename__ = 'animal_images'
+    
+    id = db.Column(db.Integer, primary_key=True)
+    animal_id = db.Column(db.Integer, db.ForeignKey('animals.id'), nullable=False)
+    url = db.Column(db.String(255), nullable=False)
+    alt_text = db.Column(db.String(100))
+
+    def to_dict(self):
+        return {
+            "url": self.url,
+            "alt_text": self.alt_text
         }

--- a/backend/app/routes/animal_routes.py
+++ b/backend/app/routes/animal_routes.py
@@ -27,9 +27,6 @@ def add_animal():
     data = request.form
     files = request.files
 
-    print(f"Form Data: {data}") 
-    print(f"Files: {files}")
-
     animal, error = animal_controller.add_animal(data, files)
     
     if error:

--- a/backend/app/routes/animal_routes.py
+++ b/backend/app/routes/animal_routes.py
@@ -24,8 +24,13 @@ def add_animal():
     if user_role != 'admin':
         return jsonify({'error': 'Access denied: admin role required'}), 403
     
-    data = request.get_json()
-    animal, error = animal_controller.add_animal(data)
+    data = request.form
+    files = request.files
+
+    print(f"Form Data: {data}") 
+    print(f"Files: {files}")
+
+    animal, error = animal_controller.add_animal(data, files)
     
     if error:
         return jsonify({'error': error}), 400

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1874,14 +1874,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1902,9 +1902,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2530,9 +2530,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3189,10 +3189,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3548,9 +3551,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/frontend/src/components/common/AnimalCard.css
+++ b/frontend/src/components/common/AnimalCard.css
@@ -22,6 +22,14 @@
   place-items: center;
 }
 
+.animal-card__image {
+  position: absolute;   
+  inset: 0;             
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
+}
+
 .animal-card__emoji {
   font-size: 5rem;
   line-height: 1;

--- a/frontend/src/components/common/AnimalCard.tsx
+++ b/frontend/src/components/common/AnimalCard.tsx
@@ -56,12 +56,26 @@ function AnimalCard({ animal, onAbout }: AnimalCardProps) {
   const temperament = animal.temperament?.toLowerCase() || '';
   const isVaccinated = Boolean(animal.vaccinated);
 
+  const images = animal.images || [];
+  const hasImages = images.length > 0;
+
   return (
     <article className="animal-card" aria-label={`${animal.name} card`}>
       <div className="animal-card__media">
-        <span className="animal-card__emoji" aria-hidden="true">
+        {!hasImages ? (<span className="animal-card__emoji" aria-hidden="true">
           {getAnimalEmoji(animalType)}
-        </span>
+        </span>) : (
+          <img 
+            src={images[0].url}
+            alt={images[0].alt_text || animal.name}
+            className="animal-card__image"
+             /* onError={(e) => {
+                (e.currentTarget as HTMLImageElement).style.display = 'none';
+              }}        this approach hides both missing image icon and alt
+                        text if image should exist but is not found  */
+          />
+        )}
+
         <span className={`animal-card__type-badge animal-card__type-badge--${animalType || 'other'}`}>
           {animalType || 'animal'}
         </span>

--- a/frontend/src/components/common/AnimalModal.css
+++ b/frontend/src/components/common/AnimalModal.css
@@ -50,9 +50,51 @@
 .animal-modal__hero {
   position: relative;
   height: 220px;
-  display: grid;
-  place-items: center;
+  width: 100%;
   background: linear-gradient(140deg, #ece9e4 0%, #ddd7cf 100%);
+  overflow: hidden;
+}
+.animal-modal__carousel {
+ position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.animal-modal__image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
+}
+
+.carousel-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  z-index: 10;
+  font-size: 24px;
+}
+
+.carousel-btn.prev { left: 10px; }
+.carousel-btn.next { right: 10px; }
+
+.carousel-indicator {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 12px;
 }
 
 .animal-modal__emoji {

--- a/frontend/src/components/common/AnimalModal.tsx
+++ b/frontend/src/components/common/AnimalModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { Animal } from '../../types/Animal';
 import './AnimalModal.css';
 
@@ -50,6 +50,12 @@ const formatAddedDate = (createdAt: Date | string) => {
 };
 
 function AnimalModal({ animal, onClose }: AnimalModalProps) {
+  const [currentImageIndex, setCurrentImageIndex] = useState(0);
+
+  useEffect(() => {
+    setCurrentImageIndex(0);
+  }, [animal]);
+
   useEffect(() => {
     if (!animal) {
       return;
@@ -75,6 +81,16 @@ function AnimalModal({ animal, onClose }: AnimalModalProps) {
   if (!animal) {
     return null;
   }
+  const images = animal.images || [];
+  const hasImages = images.length > 0;
+
+  const nextImage = () => {
+    setCurrentImageIndex((prev) => (prev + 1) % images.length);
+  };
+
+  const prevImage = () => {
+    setCurrentImageIndex((prev) => (prev - 1 + images.length) % images.length);
+  };
 
   const animalType = animal.type?.toLowerCase() || '';
   const temperament = animal.temperament?.toLowerCase() || '';
@@ -95,9 +111,28 @@ function AnimalModal({ animal, onClose }: AnimalModalProps) {
         </button>
 
         <div className="animal-modal__hero">
-          <span className="animal-modal__emoji" aria-hidden="true">
+          {!hasImages ? (<span className="animal-modal__emoji" aria-hidden="true">
             {getAnimalEmoji(animalType)}
-          </span>
+          </span>) : (<div className="animal-modal__carousel">
+            {images.length > 1 && (
+              <>
+                <button className="carousel-btn prev" onClick={prevImage} aria-label="Previous image">‹</button>
+                <button className="carousel-btn next" onClick={nextImage} aria-label="Next image">›</button>
+              </>
+            )}
+            <img
+              src={images[currentImageIndex].url}
+              alt={images[currentImageIndex].alt_text || animal.name}
+              className="animal-modal__image"
+            />
+            {images.length > 1 && (
+              <div className="carousel-indicator">
+                {currentImageIndex + 1} / {images.length}
+              </div>
+            )}
+          </div>
+          )}
+
           <span className={`animal-modal__type-badge animal-modal__type-badge--${animalType || 'other'}`}>
             {animalType || 'animal'}
           </span>

--- a/frontend/src/components/common/AnimalModal.tsx
+++ b/frontend/src/components/common/AnimalModal.tsx
@@ -53,10 +53,6 @@ function AnimalModal({ animal, onClose }: AnimalModalProps) {
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
 
   useEffect(() => {
-    setCurrentImageIndex(0);
-  }, [animal]);
-
-  useEffect(() => {
     if (!animal) {
       return;
     }

--- a/frontend/src/pages/Admin/AddAnimalPage.tsx
+++ b/frontend/src/pages/Admin/AddAnimalPage.tsx
@@ -15,7 +15,8 @@ export default function AddAnimalPage() {
     age: '',
     vaccinated: 0,
     temperament: 'calm',
-    description: ''
+    description: '',
+    images: [] as File[]
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -95,9 +96,20 @@ export default function AddAnimalPage() {
     }
   };
 
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  if (e.target.files) {
+    // Convert FileList to Array
+    const selectedFiles = Array.from(e.target.files);
+    setFormData((prev) => ({
+      ...prev,
+      images: selectedFiles
+    }));
+  }
+};
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setErrors({});
+    setErrors({});  
     setSuccessMessage('');
 
     if (!validateForm()) {
@@ -105,18 +117,25 @@ export default function AddAnimalPage() {
     }
 
     setIsSubmitting(true);
+    const dataForImages = new FormData();
+
+    dataForImages.append('name', formData.name);
+    dataForImages.append('type', formData.type);
+    dataForImages.append('breed', formData.breed);
+    dataForImages.append('size', formData.size);
+    dataForImages.append('age', formData.age);
+    dataForImages.append('vaccinated', String(formData.vaccinated));
+    dataForImages.append('temperament', formData.temperament);
+    dataForImages.append('description', formData.description);
+    
+    if (formData.images && formData.images.length > 0) {
+    formData.images.forEach((file) => {
+      dataForImages.append('images', file);
+    });
+  }
 
     try {
-      await addAnimal({
-        name: formData.name,
-        type: formData.type,
-        breed: formData.breed,
-        size: formData.size,
-        age: parseInt(formData.age),
-        vaccinated: formData.vaccinated,
-        temperament: formData.temperament,
-        description: formData.description || undefined
-      });
+      await addAnimal(dataForImages);
 
       setSuccessMessage('Animal added successfully!');
       // Reset form
@@ -128,7 +147,8 @@ export default function AddAnimalPage() {
         age: '',
         vaccinated: 0,
         temperament: 'calm',
-        description: ''
+        description: '',
+        images: []
       });
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : 'Failed to add animal';
@@ -292,16 +312,18 @@ export default function AddAnimalPage() {
               {errors.description && <p className="form-error">{errors.description}</p>}
             </div>
 
-            {/* Image field (placeholder) */}
+            {/* Image field */}
             <div className="form-field">
               <label htmlFor="image">Image Upload</label>
-              <input
-                type="file"
-                id="image"
-                name="image"
-                disabled
-                className="form-input--disabled"
-              />
+                <input
+                  type="file"
+                  id="image"
+                  name="image"
+                  multiple // allows multiple images
+                  accept="image/*" // only images
+                  onChange={handleFileChange}
+                  disabled={isSubmitting}
+                />
               {errors.image && <p className="form-error">{errors.image}</p>}
             </div>
 

--- a/frontend/src/pages/Animals/AnimalsPage.tsx
+++ b/frontend/src/pages/Animals/AnimalsPage.tsx
@@ -162,7 +162,8 @@ export default function AnimalsPage() {
         )}
       </main>
 
-      <AnimalModal animal={selectedAnimal} onClose={() => setSelectedAnimal(null)} />
+      <AnimalModal key={selectedAnimal?.id} animal={selectedAnimal}
+       onClose={() => setSelectedAnimal(null)}/>
     </>
   );
 }

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -69,16 +69,8 @@ Promise<VolunteerRegistration> => {
     throw error;
   }
 }
-export const addAnimal = async (data: {
-  name: string;
-  type: string;
-  breed: string;
-  size: string;
-  age: number;
-  vaccinated: number;
-  temperament: string;
-  description?: string;
-}): Promise<Record<string, unknown>> => {
+export const addAnimal = async (data: FormData) :
+ Promise<Record<string, unknown>> => {
   try {
     const response = await api.post<Record<string, unknown>>("/api/animals", data);
     return response.data;

--- a/frontend/src/types/Animal.ts
+++ b/frontend/src/types/Animal.ts
@@ -11,4 +11,5 @@ export interface Animal {
     description: string; 
     adopted: boolean;  // 0 = available, 1 = adopted
     created_at: Date; // default = now()
+    images?: { url: string; alt_text?: string }[];
 }


### PR DESCRIPTION
Added new animal_images table that has links to images and alt text for errors

Images are stored next to merch images in frontend/public/images

Admin in create animal tab can select one or more images that are linked to animal that is being created

In preview only one image replaces emoji placeholder, detailed view allows to browse all images

TODO: make missing image icon invisible, center alt text

Closes #59 