### PR TITLE
Feat/post creation page admin

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -54,9 +54,11 @@ def create_app():
     app.register_blueprint(donation_bp, url_prefix='/api/donations')
     from app.routes.merchandise_routes import merchandise_bp
     app.register_blueprint(merchandise_bp, url_prefix='/api/merchandise')
+    from app.routes.post_routes import post_bp
+    app.register_blueprint(post_bp, url_prefix='/api/posts')
 
     # Import all models so db.create_all() picks them up
-    from app.models import animal, donation, user, volunteer_registration, merchandise # noqa: F401
+    from app.models import animal, donation, user, volunteer_registration, merchandise, post # noqa: F401
 
     # Create tables if they dont exist
     with app.app_context():

--- a/backend/app/controllers/post_controller.py
+++ b/backend/app/controllers/post_controller.py
@@ -1,0 +1,49 @@
+# Post controller - business logic for post CRUD operations
+from app.models import db
+from app.models.post import Post
+
+
+def create_post(data, user_id):
+    """
+    Create a new post.
+    Required fields: title, content
+    Optional fields: image_url
+    Returns (post_dict, None) on success or (None, error_message) on failure.
+    """
+    if not isinstance(data, dict):
+        return None, 'Invalid request body'
+
+    title = str(data.get('title', '')).strip()
+    content = str(data.get('content', '')).strip()
+    image_url_value = data.get('image_url')
+    image_url = str(image_url_value).strip() if image_url_value is not None else None
+
+    if not title:
+        return None, 'title is required'
+
+    if not content:
+        return None, 'content is required'
+
+    post = Post(
+        title=title,
+        content=content,
+        image_url=image_url if image_url else None,
+        created_by=user_id,
+    )
+
+    try:
+        db.session.add(post)
+        db.session.commit()
+        return post.to_dict(), None
+    except Exception as exc:
+        db.session.rollback()
+        return None, f'Database error: {str(exc)}'
+
+
+def get_posts():
+    """
+    Get all posts ordered by newest first.
+    Returns list of post dictionaries.
+    """
+    posts = Post.query.order_by(Post.created_at.desc()).all()
+    return [post.to_dict() for post in posts]

--- a/backend/app/models/post.py
+++ b/backend/app/models/post.py
@@ -1,0 +1,27 @@
+# Post model
+from datetime import datetime
+
+from app.models import db
+
+
+class Post(db.Model):
+    __tablename__ = 'posts'
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    title = db.Column(db.Text, nullable=False)
+    content = db.Column(db.Text, nullable=False)
+    image_url = db.Column(db.Text)
+    created_by = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'title': self.title,
+            'content': self.content,
+            'image_url': self.image_url,
+            'created_by': self.created_by,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/app/routes/post_routes.py
+++ b/backend/app/routes/post_routes.py
@@ -1,0 +1,32 @@
+# Post routes - Flask blueprint defining API endpoints for /api/posts
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from app.controllers import post_controller, user_controller
+
+post_bp = Blueprint('posts', __name__)
+
+
+@post_bp.route('', methods=['GET'])
+def get_posts():
+    posts = post_controller.get_posts()
+    return jsonify({'posts': posts}), 200
+
+
+@post_bp.route('', methods=['POST'])
+@jwt_required()
+def create_post():
+    user_id = get_jwt_identity()
+    user_role, error = user_controller.get_user_role(user_id)
+    if error:
+        return jsonify({'error': error}), 404
+
+    if user_role != 'admin':
+        return jsonify({'error': 'Access denied: admin role required'}), 403
+
+    data = request.get_json() or {}
+    post, error = post_controller.create_post(data, user_id)
+    if error:
+        return jsonify({'error': error}), 400
+
+    return jsonify(post), 201

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,7 +61,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1390,7 +1389,6 @@
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-4.10.0.tgz",
       "integrity": "sha512-KrMOL+sH69htCIXCaZ4JluJ35bchuCCznyPyrbN8JXSGQfwBI1SuIEMZNwvy8L8ykj29t6sa5BAAiL7fNoLZ8A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -1460,7 +1458,6 @@
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1471,7 +1468,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1531,7 +1527,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -1809,7 +1804,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1874,14 +1868,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1902,9 +1896,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1932,7 +1926,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2260,7 +2253,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2530,9 +2522,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3130,7 +3122,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3189,10 +3180,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3209,7 +3203,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3219,7 +3212,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3466,7 +3458,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3548,12 +3539,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3675,7 +3665,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import AdminPage from './pages/Admin/AdminPage';
 import MerchandisePage from './pages/Merchandise/MerchandisePage';
 import AddAnimalPage from './pages/Admin/AddAnimalPage';
 import PostCreationPage from './pages/Admin/PostCreationPage';
+import PostsPage from './pages/Posts/PostsPage';
 
 function App() {
   return (
@@ -25,6 +26,7 @@ function App() {
         <Route path="/merchandise" element={<MerchandisePage />} />
         <Route path="/admin/add-animal" element={<AddAnimalPage />} />
         <Route path="/postcreation" element={<PostCreationPage />} />
+        <Route path="/posts" element={<PostsPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import DonationPage from './pages/Donation/DonationPage';
 import AdminPage from './pages/Admin/AdminPage';
 import MerchandisePage from './pages/Merchandise/MerchandisePage';
 import AddAnimalPage from './pages/Admin/AddAnimalPage';
+import PostCreationPage from './pages/Admin/PostCreationPage';
 
 function App() {
   return (
@@ -23,6 +24,7 @@ function App() {
         <Route path="/admin" element={<AdminPage />} />
         <Route path="/merchandise" element={<MerchandisePage />} />
         <Route path="/admin/add-animal" element={<AddAnimalPage />} />
+        <Route path="/postcreation" element={<PostCreationPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Admin/PostCreationPage.css
+++ b/frontend/src/pages/Admin/PostCreationPage.css
@@ -1,0 +1,175 @@
+/* Post Creation Page Styling */
+
+.post-creation-page {
+  min-height: calc(100vh - var(--nav-h));
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 32px 24px 48px;
+  background: var(--color-cream);
+}
+
+.post-creation-card {
+  width: 100%;
+  max-width: 700px;
+  border-radius: 20px;
+  border: 1px solid var(--color-border);
+  background: var(--color-card-bg);
+  padding: 36px 32px;
+  box-shadow: 0 14px 30px rgba(44, 26, 14, 0.08);
+}
+
+.post-creation-card h1 {
+  margin: 0 0 8px;
+  color: var(--color-warm-dark);
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4vw, 2.2rem);
+}
+
+.post-creation-subtitle {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.post-creation-empty {
+  margin: 20px 0 0;
+  text-align: center;
+  color: var(--color-muted);
+  padding: 40px 20px;
+  border: 1px dashed var(--color-border);
+  border-radius: 16px;
+  background: var(--color-card-bg);
+}
+
+.post-creation-form {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.post-creation-form__full-width {
+  grid-column: 1;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-field label {
+  font-weight: 500;
+  color: var(--color-warm-dark);
+  font-size: 0.95rem;
+}
+
+.form-field input,
+.form-field textarea {
+  border-radius: 10px;
+  border: 1px solid var(--color-border);
+  background: #fff;
+  padding: 12px;
+  font: inherit;
+  color: var(--color-warm-dark);
+  outline: none;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+  font-size: 0.95rem;
+}
+
+.form-field input:focus,
+.form-field textarea:focus {
+  border-color: var(--color-terracotta);
+  box-shadow: 0 0 0 3px rgba(193, 98, 63, 0.14);
+}
+
+.form-field input:disabled,
+.form-field textarea:disabled {
+  background-color: #f9f8f7;
+  color: var(--color-muted);
+  cursor: not-allowed;
+}
+
+.form-field textarea {
+  resize: vertical;
+  min-height: 160px;
+  font-family: inherit;
+}
+
+.form-error {
+  margin: 0;
+  color: #b42318;
+  font-size: 0.88rem;
+  line-height: 1.3;
+}
+
+.form-error--general {
+  padding: 12px;
+  border-radius: 8px;
+  background-color: rgba(180, 35, 24, 0.08);
+  margin: 0;
+}
+
+.form-success {
+  margin: 0;
+  padding: 12px;
+  border-radius: 8px;
+  background-color: rgba(29, 122, 63, 0.08);
+  color: #1d7a3f;
+  font-size: 0.92rem;
+  font-weight: 500;
+}
+
+.post-creation-form__submit,
+.post-creation-form__secondary {
+  width: 100%;
+  height: 44px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.post-creation-form__submit {
+  background: var(--color-terracotta);
+  color: #fff;
+}
+
+.post-creation-form__submit:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.post-creation-form__submit:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.post-creation-form__secondary {
+  margin-top: 16px;
+  background: transparent;
+  border-color: var(--color-terracotta);
+  color: var(--color-terracotta);
+}
+
+.post-creation-form__secondary:hover:not(:disabled) {
+  background: var(--color-terracotta);
+  color: #fff;
+}
+
+@media (max-width: 480px) {
+  .post-creation-page {
+    padding: 24px 16px 32px;
+  }
+
+  .post-creation-card {
+    padding: 24px 20px;
+  }
+
+  .post-creation-form {
+    gap: 14px;
+  }
+}

--- a/frontend/src/pages/Admin/PostCreationPage.tsx
+++ b/frontend/src/pages/Admin/PostCreationPage.tsx
@@ -1,0 +1,192 @@
+// Post Creation page - admin form for creating shelter posts
+import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import Navbar from '../../components/layout/Navbar';
+import { getUsers } from '../../services/adminService';
+import { createPost } from '../../services/postService';
+import './PostCreationPage.css';
+
+export default function PostCreationPage() {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    title: '',
+    content: '',
+    image_url: '',
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [isAdmin, setIsAdmin] = useState(true);
+  const [loggedIn, setLoggedIn] = useState(true);
+
+  useEffect(() => {
+    const checkAdminAccess = async () => {
+      try {
+        await getUsers();
+      } catch (error) {
+        if (error instanceof Error && error.message === 'NOT_LOGGED_IN') {
+          setLoggedIn(false);
+        } else if (error instanceof Error && error.message === 'USER_NOT_ADMIN') {
+          setIsAdmin(false);
+        } else {
+          console.error('Admin access check failed', error);
+        }
+      }
+    };
+
+    checkAdminAccess();
+  }, []);
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    if (!formData.title || formData.title.trim() === '') {
+      newErrors.title = 'Title is required';
+    }
+
+    if (!formData.content || formData.content.trim() === '') {
+      newErrors.content = 'Content is required';
+    }
+
+    if (formData.image_url && formData.image_url.trim() !== '') {
+      try {
+        new URL(formData.image_url.trim());
+      } catch {
+        newErrors.image_url = 'Image URL must be a valid URL';
+      }
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+
+    if (errors[name]) {
+      setErrors((prev) => ({ ...prev, [name]: '' }));
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setErrors({});
+    setSuccessMessage('');
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await createPost({
+        title: formData.title.trim(),
+        content: formData.content.trim(),
+        image_url: formData.image_url.trim() || undefined,
+      });
+
+      setSuccessMessage('Post created successfully!');
+      setFormData({
+        title: '',
+        content: '',
+        image_url: '',
+      });
+    } catch (error: unknown) {
+      const errorMsg = error instanceof Error ? error.message : 'Failed to create post';
+      if (errorMsg === 'NOT_LOGGED_IN') {
+        setErrors({ general: 'Please log in to continue' });
+      } else if (errorMsg === 'USER_NOT_ADMIN') {
+        setErrors({ general: 'Only admins can create posts' });
+      } else {
+        setErrors({ general: errorMsg });
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Navbar />
+      <main className="post-creation-page">
+        <section className="post-creation-card">
+          <h1>Create New Post</h1>
+          <p className="post-creation-subtitle">
+            Publish shelter news, stories, and updates for visitors.
+          </p>
+
+          {(!isAdmin || !loggedIn) && (
+            <p className="post-creation-empty">
+              Please log in as admin to create posts.
+            </p>
+          )}
+
+          {isAdmin && loggedIn && (
+            <form onSubmit={handleSubmit} className="post-creation-form">
+              <div className="form-field post-creation-form__full-width">
+                <label htmlFor="title">Title</label>
+                <input
+                  type="text"
+                  id="title"
+                  name="title"
+                  value={formData.title}
+                  onChange={handleChange}
+                  disabled={isSubmitting}
+                />
+                {errors.title && <p className="form-error">{errors.title}</p>}
+              </div>
+
+              <div className="form-field post-creation-form__full-width">
+                <label htmlFor="content">Content</label>
+                <textarea
+                  id="content"
+                  name="content"
+                  value={formData.content}
+                  onChange={handleChange}
+                  disabled={isSubmitting}
+                  rows={8}
+                />
+                {errors.content && <p className="form-error">{errors.content}</p>}
+              </div>
+
+              <div className="form-field post-creation-form__full-width">
+                <label htmlFor="image_url">Image URL (Optional)</label>
+                <input
+                  type="url"
+                  id="image_url"
+                  name="image_url"
+                  value={formData.image_url}
+                  onChange={handleChange}
+                  disabled={isSubmitting}
+                  placeholder="https://example.com/image.jpg"
+                />
+                {errors.image_url && <p className="form-error">{errors.image_url}</p>}
+              </div>
+
+              {errors.general && <p className="form-error form-error--general">{errors.general}</p>}
+              {successMessage && <p className="form-success">{successMessage}</p>}
+
+              <button type="submit" disabled={isSubmitting} className="post-creation-form__submit">
+                {isSubmitting ? 'Creating Post...' : 'Create Post'}
+              </button>
+            </form>
+          )}
+
+          <button
+            type="button"
+            onClick={() => navigate('/admin')}
+            className="post-creation-form__secondary"
+          >
+            Back to Admin Dashboard
+          </button>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/frontend/src/pages/Posts/PostsPage.css
+++ b/frontend/src/pages/Posts/PostsPage.css
@@ -1,0 +1,157 @@
+/* Posts Page Styling */
+
+.posts-page {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 48px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.posts-page__header h1 {
+  margin: 0;
+  color: var(--color-warm-dark);
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 3vw, 2.8rem);
+}
+
+.posts-page__header p {
+  margin: 8px 0 0;
+  color: var(--color-muted);
+  font-size: 1rem;
+}
+
+.posts-page__loading,
+.posts-page__error,
+.posts-page__empty {
+  margin: 20px 0 0;
+  text-align: center;
+  color: var(--color-muted);
+  padding: 40px 20px;
+  border: 1px dashed var(--color-border);
+  border-radius: 16px;
+  background: var(--color-card-bg);
+}
+
+.posts-page__error {
+  color: #b42318;
+  border-color: #b42318;
+  background: rgba(180, 35, 24, 0.08);
+}
+
+.posts-page__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.posts-page__card {
+  border-radius: 16px;
+  border: 1px solid var(--color-border);
+  background: var(--color-card-bg);
+  overflow: hidden;
+  box-shadow: 0 8px 16px rgba(44, 26, 14, 0.06);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+}
+
+.posts-page__card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(44, 26, 14, 0.12);
+}
+
+.posts-page__card-image {
+  width: 100%;
+  height: 200px;
+  overflow: hidden;
+  background: #f5f5f5;
+}
+
+.posts-page__card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 300ms ease;
+}
+
+.posts-page__card:hover .posts-page__card-image img {
+  transform: scale(1.05);
+}
+
+.posts-page__card-content {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+}
+
+.posts-page__card-title {
+  margin: 0;
+  color: var(--color-warm-dark);
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  line-height: 1.4;
+  min-height: 2.5rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.posts-page__card-text {
+  margin: 0;
+  color: var(--color-warm-dark);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.posts-page__card-meta {
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.posts-page__card-date {
+  font-weight: 500;
+}
+
+.posts-page__card-author {
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .posts-page {
+    padding: 32px 18px;
+  }
+
+  .posts-page__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .posts-page__card-image {
+    height: 160px;
+  }
+
+  .posts-page__card-content {
+    padding: 16px;
+  }
+
+  .posts-page__card-title {
+    font-size: 1.1rem;
+  }
+}

--- a/frontend/src/pages/Posts/PostsPage.tsx
+++ b/frontend/src/pages/Posts/PostsPage.tsx
@@ -1,0 +1,91 @@
+// Posts page — public page for viewing all shelter posts
+import { useEffect, useState } from 'react';
+
+import Navbar from '../../components/layout/Navbar';
+import { getPosts } from '../../services/postService';
+import type { Post } from '../../types/Post';
+import './PostsPage.css';
+
+export default function PostsPage() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await getPosts();
+        setPosts(data);
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : 'Failed to load posts';
+        setError(errorMsg);
+        console.error('Fetch posts failed', err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchPosts();
+  }, []);
+
+  const formatDate = (dateString: string): string => {
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      });
+    } catch {
+      return dateString;
+    }
+  };
+
+  return (
+    <>
+      <Navbar />
+
+      <main className="posts-page">
+        <header className="posts-page__header">
+          <h1>Shelter News & Stories</h1>
+          <p>Read updates and stories from our shelter</p>
+        </header>
+
+        {isLoading && <p className="posts-page__loading">Loading posts...</p>}
+
+        {error && <p className="posts-page__error">Error: {error}</p>}
+
+        {!isLoading && !error && posts.length === 0 && (
+          <p className="posts-page__empty">No posts yet. Check back soon!</p>
+        )}
+
+        {!isLoading && !error && posts.length > 0 && (
+          <section className="posts-page__grid" aria-label="Shelter posts">
+            {posts.map((post) => (
+              <article key={post.id} className="posts-page__card">
+                {post.image_url && (
+                  <div className="posts-page__card-image">
+                    <img src={post.image_url} alt={post.title} />
+                  </div>
+                )}
+
+                <div className="posts-page__card-content">
+                  <h2 className="posts-page__card-title">{post.title}</h2>
+
+                  <p className="posts-page__card-text">{post.content}</p>
+
+                  <footer className="posts-page__card-meta">
+                    <span className="posts-page__card-date">{formatDate(post.created_at)}</span>
+                    <span className="posts-page__card-author">By Admin #{post.created_by}</span>
+                  </footer>
+                </div>
+              </article>
+            ))}
+          </section>
+        )}
+      </main>
+    </>
+  );
+}

--- a/frontend/src/services/postService.ts
+++ b/frontend/src/services/postService.ts
@@ -1,0 +1,31 @@
+// Post service — API calls for listing and creating posts
+import axios from 'axios';
+
+import api from './api';
+import type { CreatePostRequest, Post } from '../types/Post';
+
+export const getPosts = async (): Promise<Post[]> => {
+  const response = await api.get<{ posts: Post[] }>('/api/posts');
+  return response.data.posts;
+};
+
+export const createPost = async (data: CreatePostRequest): Promise<Post> => {
+  try {
+    const response = await api.post<Post>('/api/posts', data);
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) {
+        throw new Error('NOT_LOGGED_IN');
+      }
+      if (error.response?.status === 403) {
+        throw new Error('USER_NOT_ADMIN');
+      }
+      if (error.response?.status === 400) {
+        const serverError = error.response.data?.error;
+        throw new Error(serverError || 'Validation error');
+      }
+    }
+    throw error;
+  }
+};

--- a/frontend/src/types/Post.ts
+++ b/frontend/src/types/Post.ts
@@ -1,0 +1,16 @@
+// Post type — TypeScript interfaces mirroring the backend Post model
+export interface Post {
+  id: number;
+  title: string;
+  content: string;
+  image_url: string | null;
+  created_by: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreatePostRequest {
+  title: string;
+  content: string;
+  image_url?: string;
+}


### PR DESCRIPTION
## Overview
Implemented a complete Post management system following MVC architecture, enabling admins to create shelter news/stories while allowing public viewing of all posts.

---

## Changes

### Backend
- Added **Post model** with fields:
  - `title`
  - `content`
  - `image_url`
  - `created_by`
  - `created_at`
  - `updated_at`

- Implemented `post_controller.py` with:
  - `create_post(data, user_id)` – validates and creates posts
  - `get_posts()` – retrieves all posts ordered by newest first

- Created `post_routes.py` blueprint with:
  - `GET /api/posts` – public, returns all posts
  - `POST /api/posts` – admin-only, creates new post with JWT authentication

- Registered blueprint in `app/__init__.py` with model import for DB initialization

---

### Frontend
- Added Post TypeScript interfaces:
  - `Post`
  - `CreatePostRequest`

- Implemented `postService.ts` with error-mapped API calls:
  - `getPosts`
  - `createPost`

- Created admin-only `/postcreation` page:
  - Access check via `getUsers()` from `adminService`
  - Form validation:
    - required: title, content
    - optional: image URL
  - Admin guard blocks non-admin/logged-out users

- Created public `/posts` page:
  - Accessible without login
  - Displays posts in responsive grid
  - Shows:
    - title
    - content
    - image (if provided)
    - date
    - author info
  - Handles loading, error, and empty states gracefully

- Updated routing in `App.tsx` (no Navbar modifications)

---

## Architecture
Follows existing MVC pattern:

- **Models**: `models/post.py`
- **Controllers**: `controllers/post_controller.py`
- **Routes**: `routes/post_routes.py`
- **Services**: `services/postService.ts`
- **Types**: `types/Post.ts`

---

## Access Patterns
- `/posts` → Public viewing (everyone)
- `/postcreation` → Admin-only creation (login + admin role required)

