### PR TITLE
feat: implement adoption handling

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -50,6 +50,8 @@ def create_app():
     app.register_blueprint(volunteer_registration_bp, url_prefix='/api')
     from app.routes.admin_routes import admin_registration_bp
     app.register_blueprint(admin_registration_bp, url_prefix='/api')
+    from app.routes.adoption_request_routes import adoption_request_bp
+    app.register_blueprint(adoption_request_bp, url_prefix='/api')
     from app.routes.donation_routes import donation_bp
     app.register_blueprint(donation_bp, url_prefix='/api/donations')
     from app.routes.merchandise_routes import merchandise_bp
@@ -58,7 +60,7 @@ def create_app():
     app.register_blueprint(post_bp, url_prefix='/api/posts')
 
     # Import all models so db.create_all() picks them up
-    from app.models import animal, donation, user, volunteer_registration, merchandise, post # noqa: F401
+    from app.models import animal, donation, user, volunteer_registration, merchandise, post, adoption_request # noqa: F401
 
     # Create tables if they dont exist
     with app.app_context():

--- a/backend/app/controllers/adoption_request_controller.py
+++ b/backend/app/controllers/adoption_request_controller.py
@@ -1,0 +1,88 @@
+from app.models import db
+from app.models.adoption_request import AdoptionRequest
+from app.models.animal import Animal
+
+
+def create_adoption_request(user_id, animal_id):
+    animal = Animal.query.get(animal_id)
+    if not animal:
+        return None, "Animal not found"
+
+    if animal.adopted == 1:
+        return None, "This animal has already been adopted"
+
+    existing = AdoptionRequest.query.filter_by(
+        user_id=user_id, animal_id=animal_id, status='pending'
+    ).first()
+    if existing:
+        return None, "You already have a pending request for this animal"
+
+    try:
+        request = AdoptionRequest(
+            user_id=user_id,
+            animal_id=animal_id,
+            status='pending'
+        )
+        db.session.add(request)
+        db.session.commit()
+        return request.to_dict(), None
+    except Exception as e:
+        db.session.rollback()
+        return None, str(e)
+
+
+def get_user_adoption_requests(user_id):
+    requests = AdoptionRequest.query.filter_by(user_id=user_id)\
+        .order_by(AdoptionRequest.created_at.desc()).all()
+    return [r.to_dict() for r in requests]
+
+
+def get_all_pending_requests():
+    requests = AdoptionRequest.query.filter_by(status='pending')\
+        .order_by(AdoptionRequest.created_at.asc()).all()
+    return [r.to_dict() for r in requests]
+
+
+def approve_adoption_request(request_id):
+    adoption_request = AdoptionRequest.query.get(request_id)
+    if not adoption_request:
+        return None, "Adoption request not found"
+
+    if adoption_request.status != 'pending':
+        return None, "This request is no longer pending"
+
+    try:
+        adoption_request.status = 'approved'
+
+        animal = Animal.query.get(adoption_request.animal_id)
+        if animal:
+            animal.adopted = 1
+
+        AdoptionRequest.query.filter(
+            AdoptionRequest.animal_id == adoption_request.animal_id,
+            AdoptionRequest.id != request_id,
+            AdoptionRequest.status == 'pending'
+        ).update({'status': 'cancelled'})
+
+        db.session.commit()
+        return adoption_request.to_dict(), None
+    except Exception as e:
+        db.session.rollback()
+        return None, str(e)
+
+
+def reject_adoption_request(request_id):
+    adoption_request = AdoptionRequest.query.get(request_id)
+    if not adoption_request:
+        return None, "Adoption request not found"
+
+    if adoption_request.status != 'pending':
+        return None, "This request is no longer pending"
+
+    try:
+        adoption_request.status = 'rejected'
+        db.session.commit()
+        return adoption_request.to_dict(), None
+    except Exception as e:
+        db.session.rollback()
+        return None, str(e)

--- a/backend/app/models/adoption_request.py
+++ b/backend/app/models/adoption_request.py
@@ -1,0 +1,27 @@
+from app.models import db
+from datetime import datetime
+
+
+class AdoptionRequest(db.Model):
+    __tablename__ = 'adoption_requests'
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    animal_id = db.Column(db.Integer, db.ForeignKey('animals.id'), nullable=False)
+    status = db.Column(db.Text, nullable=False, default='pending')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    animal = db.relationship('Animal', backref='adoption_requests')
+    user = db.relationship('User', backref='adoption_requests')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'user_id': self.user_id,
+            'animal_id': self.animal_id,
+            'animal_name': self.animal.name if self.animal else None,
+            'animal_type': self.animal.type if self.animal else None,
+            'user_name': self.user.name if self.user else None,
+            'status': self.status,
+            'created_at': self.created_at.isoformat() if self.created_at else None
+        }

--- a/backend/app/routes/admin_routes.py
+++ b/backend/app/routes/admin_routes.py
@@ -1,7 +1,7 @@
 # Admin routes - Flask blueprint defining API endpoints for /api/admin
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
-from app.controllers import volunteer_registration_controller, user_controller
+from app.controllers import volunteer_registration_controller, user_controller, adoption_request_controller
 
 admin_registration_bp = Blueprint('adminRegistrations', __name__)
 
@@ -82,7 +82,70 @@ def attendance_registration():
     registration, error = volunteer_registration_controller.mark_attendace_registration(reg_id)
     if error:
         return jsonify({"error": error}), 404
-    
-   
-    
+
+
+
     return jsonify(registration), 201
+
+
+@admin_registration_bp.route('/admin/adoption-requests', methods=['GET'])
+@jwt_required()
+def get_all_adoption_requests():
+    user_id = get_jwt_identity()
+    user_role, error = user_controller.get_user_role(user_id)
+    if error:
+        return jsonify({"error": error}), 404
+
+    if(user_role!='admin'):
+        return jsonify({"error": "/admin/adoption-requests access permitted for admins only"}), 403
+
+    requests = adoption_request_controller.get_all_pending_requests()
+    return jsonify({"adoptionRequests": requests}), 200
+
+
+@admin_registration_bp.route('/admin/approveAdoption', methods=['POST'])
+@jwt_required()
+def approve_adoption():
+    user_id = get_jwt_identity()
+    user_role, error = user_controller.get_user_role(user_id)
+    if error:
+        return jsonify({"error": error}), 404
+
+    if(user_role!='admin'):
+        return jsonify({"error": "/admin/approveAdoption access permitted for admins only"}), 403
+
+    data = request.get_json()
+    req_id = data.get('id')
+
+    if not req_id:
+        return jsonify({"error": "ID is required"}), 400
+
+    adoption_request, error = adoption_request_controller.approve_adoption_request(req_id)
+    if error:
+        return jsonify({"error": error}), 404
+
+    return jsonify(adoption_request), 201
+
+
+@admin_registration_bp.route('/admin/rejectAdoption', methods=['POST'])
+@jwt_required()
+def reject_adoption():
+    user_id = get_jwt_identity()
+    user_role, error = user_controller.get_user_role(user_id)
+    if error:
+        return jsonify({"error": error}), 404
+
+    if(user_role!='admin'):
+        return jsonify({"error": "/admin/rejectAdoption access permitted for admins only"}), 403
+
+    data = request.get_json()
+    req_id = data.get('id')
+
+    if not req_id:
+        return jsonify({"error": "ID is required"}), 400
+
+    adoption_request, error = adoption_request_controller.reject_adoption_request(req_id)
+    if error:
+        return jsonify({"error": error}), 404
+
+    return jsonify(adoption_request), 201

--- a/backend/app/routes/adoption_request_routes.py
+++ b/backend/app/routes/adoption_request_routes.py
@@ -1,0 +1,30 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from app.controllers import adoption_request_controller
+
+adoption_request_bp = Blueprint('adoptionRequests', __name__)
+
+
+@adoption_request_bp.route('/adoption-requests', methods=['POST'])
+@jwt_required()
+def create_adoption_request():
+    user_id = get_jwt_identity()
+    data = request.get_json()
+    animal_id = data.get('animal_id')
+
+    if not animal_id:
+        return jsonify({"error": "animal_id is required"}), 400
+
+    adoption_request, error = adoption_request_controller.create_adoption_request(user_id, animal_id)
+    if error:
+        return jsonify({"error": error}), 400
+
+    return jsonify(adoption_request), 201
+
+
+@adoption_request_bp.route('/adoption-requests', methods=['GET'])
+@jwt_required()
+def get_user_adoption_requests():
+    user_id = get_jwt_identity()
+    requests = adoption_request_controller.get_user_adoption_requests(user_id)
+    return jsonify({"adoptionRequests": requests}), 200

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import DonationPage from './pages/Donation/DonationPage';
 import ProfilePage from './pages/Profile/ProfilePage';
 import AdminDashboardPage from './pages/Admin/AdminDashboardPage';
 import AdminPage from './pages/Admin/AdminPage';
+import AdminAdoptionRequestsPage from './pages/Admin/AdminAdoptionRequestsPage';
 import MerchandisePage from './pages/Merchandise/MerchandisePage';
 import CartPage from './pages/Merchandise/CartPage';
 import AddAnimalPage from './pages/Admin/AddAnimalPage';
@@ -29,6 +30,7 @@ function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/admin" element={<AdminDashboardPage />} />
         <Route path="/admin/volunteer-registrations" element={<AdminPage />} />
+        <Route path="/admin/adoption-requests" element={<AdminAdoptionRequestsPage />} />
         <Route path="/admin/post-creation" element={<PostCreationPage />} />
         <Route path="/merchandise" element={<MerchandisePage />} />
         <Route path="/cart" element={<CartPage />} />

--- a/frontend/src/components/common/AnimalCard.css
+++ b/frontend/src/components/common/AnimalCard.css
@@ -153,6 +153,28 @@
   background: #d4f4e1;
 }
 
+.animal-card__adopt-btn {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 0.95rem;
+  background: #ff9800;
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 180ms ease;
+}
+
+.animal-card__adopt-btn:hover:not(:disabled) {
+  background: #e68a00;
+}
+
+.animal-card__adopt-btn:disabled {
+  background: #ccc;
+  color: #777;
+  cursor: not-allowed;
+}
+
 .animal-card__about-btn {
   margin-top: auto;
   border: 1px solid var(--color-terracotta);

--- a/frontend/src/components/common/AnimalCard.tsx
+++ b/frontend/src/components/common/AnimalCard.tsx
@@ -1,6 +1,7 @@
 import type { Animal } from '../../types/Animal';
 import { useState } from 'react';
 import { addFavoriteAnimal, removeFavoriteAnimal } from '../../services/animalService';
+import { createAdoptionRequest } from '../../services/adoptionRequestService';
 import './AnimalCard.css';
 
 type AnimalCardProps = {
@@ -9,6 +10,8 @@ type AnimalCardProps = {
   isFavorited: boolean;
   onFavorite: (animalId: number) => void;
   onFavoriteRemove: (animalId: number) => void;
+  adoptionStatus?: 'pending' | 'approved' | null;
+  onAdoptionRequest?: (animalId: number) => void;
 };
 
 const getAnimalEmoji = (type: string) => {
@@ -55,14 +58,36 @@ const getTemperamentClass = (temperament: string) => {
   return '';
 };
 
-function AnimalCard({ animal, onAbout, isFavorited, onFavorite, onFavoriteRemove }: AnimalCardProps) {
+function AnimalCard({ animal, onAbout, isFavorited, onFavorite, onFavoriteRemove, adoptionStatus, onAdoptionRequest }: AnimalCardProps) {
   const animalType = animal.type?.toLowerCase() || '';
   const size = animal.size?.toLowerCase() || '';
   const temperament = animal.temperament?.toLowerCase() || '';
   const isVaccinated = Boolean(animal.vaccinated);
+  const isAdopted = Boolean(animal.adopted);
   const [isLoadingFavorite, setIsLoadingFavorite] = useState(false);
+  const [isLoadingAdopt, setIsLoadingAdopt] = useState(false);
   const images = animal.images || [];
   const hasImages = images.length > 0;
+
+  const handleAdopt = async () => {
+    try {
+      setIsLoadingAdopt(true);
+      await createAdoptionRequest(animal.id);
+      onAdoptionRequest?.(animal.id);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        if (err.message === "NOT_LOGGED_IN") {
+          alert("Please log in to adopt animals.");
+        } else {
+          alert(err.message);
+        }
+      } else {
+        alert("An unexpected error occurred");
+      }
+    } finally {
+      setIsLoadingAdopt(false);
+    }
+  };
 
   const handleFavorite = async () => {
     try {
@@ -141,6 +166,21 @@ function AnimalCard({ animal, onAbout, isFavorited, onFavorite, onFavoriteRemove
             <span className="animal-card__tag animal-card__tag--vaccinated">💉 vaccinated</span>
           ) : null}
         </div>
+
+        {!isAdopted && (
+          <button
+            type="button"
+            className="animal-card__adopt-btn"
+            onClick={handleAdopt}
+            disabled={adoptionStatus === 'pending' || isLoadingAdopt}
+          >
+            {adoptionStatus === 'pending'
+              ? 'Request Pending'
+              : isLoadingAdopt
+                ? 'Submitting...'
+                : 'Adopt Me'}
+          </button>
+        )}
 
         <button type="button" className="animal-card__about-btn" onClick={() => onAbout(animal)}>
           About {animal.name}

--- a/frontend/src/components/common/AnimalModal.tsx
+++ b/frontend/src/components/common/AnimalModal.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from 'react';
 import type { Animal } from '../../types/Animal';
+import { createAdoptionRequest } from '../../services/adoptionRequestService';
 import './AnimalModal.css';
 
 type AnimalModalProps = {
   animal: Animal | null;
   onClose: () => void;
+  onAdopt?: (animalId: number) => void;
+  adoptionStatus?: 'pending' | 'approved' | null;
 };
 
 const TEMPERAMENT_COPY: Record<string, string> = {
@@ -49,8 +52,30 @@ const formatAddedDate = (createdAt: Date | string) => {
   return date.toLocaleDateString();
 };
 
-function AnimalModal({ animal, onClose }: AnimalModalProps) {
+function AnimalModal({ animal, onClose, onAdopt, adoptionStatus }: AnimalModalProps) {
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
+  const [isLoadingAdopt, setIsLoadingAdopt] = useState(false);
+
+  const handleAdopt = async () => {
+    if (!animal || !onAdopt) return;
+    try {
+      setIsLoadingAdopt(true);
+      await createAdoptionRequest(animal.id);
+      onAdopt(animal.id);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        if (err.message === "NOT_LOGGED_IN") {
+          alert("Please log in to adopt animals.");
+        } else {
+          alert(err.message);
+        }
+      } else {
+        alert("An unexpected error occurred");
+      }
+    } finally {
+      setIsLoadingAdopt(false);
+    }
+  };
 
   useEffect(() => {
     if (!animal) {
@@ -142,8 +167,17 @@ function AnimalModal({ animal, onClose }: AnimalModalProps) {
               <p className="animal-modal__breed">{animal.breed}</p>
             </div>
             {!isAdopted ? (
-              <button type="button" className="animal-modal__adopt-btn">
-                Adopt Me 🐾
+              <button
+                type="button"
+                className="animal-modal__adopt-btn"
+                onClick={handleAdopt}
+                disabled={adoptionStatus === 'pending' || !onAdopt || isLoadingAdopt}
+              >
+                {adoptionStatus === 'pending'
+                  ? 'Request Pending'
+                  : isLoadingAdopt
+                    ? 'Submitting...'
+                    : 'Adopt Me 🐾'}
               </button>
             ) : null}
           </header>

--- a/frontend/src/pages/Admin/AdminAdoptionRequestsPage.css
+++ b/frontend/src/pages/Admin/AdminAdoptionRequestsPage.css
@@ -1,0 +1,164 @@
+.admin-adoption-page {
+  width: 100%;
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 48px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.admin-adoption-page__header h1 {
+  margin: 0;
+  color: var(--color-warm-dark);
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 3vw, 2.8rem);
+}
+
+.admin-adoption-page__header p {
+  margin: 10px 0 0;
+  color: var(--color-muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.admin-adoption-page__back-link {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 12px;
+  color: var(--color-terracotta);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.admin-adoption-page__back-link:hover {
+  text-decoration: underline;
+}
+
+.admin-adoption-page__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 24px;
+}
+
+.admin-adoption-page__empty {
+  margin: 20px 0 0;
+  text-align: center;
+  color: var(--color-muted);
+  padding: 40px 20px;
+  border: 1px dashed var(--color-border);
+  border-radius: 16px;
+  background: var(--color-card-bg);
+}
+
+.admin-adoption-card {
+  padding: 24px;
+  background: var(--color-card-bg);
+  border-radius: 16px;
+  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.admin-adoption-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.admin-adoption-card__animal-name {
+  font-weight: 600;
+  font-size: 1.2rem;
+  color: var(--color-warm-dark);
+}
+
+.admin-adoption-card__animal-type {
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  text-transform: capitalize;
+  color: #fff;
+}
+
+.admin-adoption-card__animal-type--dog {
+  background: #7a4e2f;
+}
+
+.admin-adoption-card__animal-type--cat {
+  background: #4d6688;
+}
+
+.admin-adoption-card__animal-type--other {
+  background: var(--color-muted);
+}
+
+.admin-adoption-card__details {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.admin-adoption-card__actions {
+  display: flex;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.admin-adoption-card__approve-btn,
+.admin-adoption-card__reject-btn {
+  flex: 1;
+  padding: 0.6rem 1rem;
+  border: none;
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 180ms ease;
+}
+
+.admin-adoption-card__approve-btn {
+  background: #059669;
+  color: #fff;
+}
+
+.admin-adoption-card__approve-btn:hover {
+  background: #047857;
+}
+
+.admin-adoption-card__reject-btn {
+  background: #dc2626;
+  color: #fff;
+}
+
+.admin-adoption-card__reject-btn:hover {
+  background: #b91c1c;
+}
+
+.admin-adoption-card__approve-btn:disabled,
+.admin-adoption-card__reject-btn:disabled {
+  background: #ccc;
+  color: #777;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .admin-adoption-page {
+    padding: 32px 18px;
+    gap: 20px;
+  }
+}
+
+@media (max-width: 480px) {
+  .admin-adoption-page {
+    padding: 24px 16px;
+  }
+
+  .admin-adoption-page__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/Admin/AdminAdoptionRequestsPage.tsx
+++ b/frontend/src/pages/Admin/AdminAdoptionRequestsPage.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { getAdminAdoptionRequests, approveAdoptionRequest, rejectAdoptionRequest } from '../../services/adoptionRequestService';
+import type { AdoptionRequest } from '../../types/AdoptionRequest';
+import Navbar from '../../components/layout/Navbar';
+import './AdminAdoptionRequestsPage.css';
+
+export default function AdminAdoptionRequestsPage() {
+  const [requests, setRequests] = useState<AdoptionRequest[]>([]);
+  const [isAdmin, setIsAdmin] = useState(true);
+  const [loggedIn, setLoggedIn] = useState(true);
+  const [loadingIds, setLoadingIds] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    const fetchRequests = async () => {
+      try {
+        const data = await getAdminAdoptionRequests();
+        setRequests(data);
+      } catch (error) {
+        if (error instanceof Error && error.message === 'NOT_LOGGED_IN') {
+          setLoggedIn(false);
+        } else if (error instanceof Error && error.message === 'USER_NOT_ADMIN') {
+          setIsAdmin(false);
+        } else {
+          console.error('Adoption requests fetch failed', error);
+        }
+      }
+    };
+
+    fetchRequests();
+  }, []);
+
+  const handleApprove = async (id: number) => {
+    setLoadingIds((prev) => new Set(prev).add(id));
+    try {
+      await approveAdoptionRequest(id);
+      setRequests((prev) => prev.filter((req) => req.id !== id));
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to approve request');
+    } finally {
+      setLoadingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  };
+
+  const handleReject = async (id: number) => {
+    setLoadingIds((prev) => new Set(prev).add(id));
+    try {
+      await rejectAdoptionRequest(id);
+      setRequests((prev) => prev.filter((req) => req.id !== id));
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to reject request');
+    } finally {
+      setLoadingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  };
+
+  return (
+    <>
+      <Navbar />
+      <main className="admin-adoption-page">
+        <header className="admin-adoption-page__header">
+          <h1>Adoption request management</h1>
+          <Link to="/admin" className="admin-adoption-page__back-link">
+            Back to Admin Dashboard
+          </Link>
+          {(!isAdmin || !loggedIn) && (
+            <p className="admin-adoption-page__empty">
+              Please log in as admin to see adoption requests.
+            </p>
+          )}
+
+          {isAdmin && loggedIn && (
+            <p>{requests.length} pending adoption request{requests.length !== 1 ? 's' : ''}</p>
+          )}
+        </header>
+
+        {isAdmin && loggedIn && (
+          <>
+            {requests.length === 0 ? (
+              <p className="admin-adoption-page__empty">No pending adoption requests.</p>
+            ) : (
+              <section className="admin-adoption-page__grid" aria-label="Adoption request cards">
+                {requests.map((req) => {
+                  const animalType = req.animal_type?.toLowerCase() || 'other';
+                  const isLoading = loadingIds.has(req.id);
+
+                  return (
+                    <article key={req.id} className="admin-adoption-card">
+                      <div className="admin-adoption-card__header">
+                        <span className="admin-adoption-card__animal-name">{req.animal_name}</span>
+                        <span className={`admin-adoption-card__animal-type admin-adoption-card__animal-type--${animalType}`}>
+                          {animalType}
+                        </span>
+                      </div>
+                      <div className="admin-adoption-card__details">
+                        <span>Requested by: <strong>{req.user_name}</strong></span>
+                        <span>Submitted: {new Date(req.created_at).toLocaleDateString()}</span>
+                      </div>
+                      <div className="admin-adoption-card__actions">
+                        <button
+                          type="button"
+                          className="admin-adoption-card__approve-btn"
+                          onClick={() => handleApprove(req.id)}
+                          disabled={isLoading}
+                        >
+                          {isLoading ? 'Processing...' : 'Approve'}
+                        </button>
+                        <button
+                          type="button"
+                          className="admin-adoption-card__reject-btn"
+                          onClick={() => handleReject(req.id)}
+                          disabled={isLoading}
+                        >
+                          {isLoading ? 'Processing...' : 'Reject'}
+                        </button>
+                      </div>
+                    </article>
+                  );
+                })}
+              </section>
+            )}
+          </>
+        )}
+      </main>
+    </>
+  );
+}

--- a/frontend/src/pages/Admin/AdminDashboardPage.tsx
+++ b/frontend/src/pages/Admin/AdminDashboardPage.tsx
@@ -20,6 +20,14 @@ const adminShortcuts = [
     actionLabel: 'Create a post',
   },
   {
+    title: 'Adoption request management',
+    description: 'Review and approve or reject animal adoption requests from users.',
+    to: '/admin/adoption-requests',
+    icon: '🏠',
+    badge: 'Active',
+    actionLabel: 'Manage adoptions',
+  },
+  {
     title: 'Animal management',
     description: 'Add new dogs, cats, and other animals to the shelter listings.',
     to: '/admin/add-animal',

--- a/frontend/src/pages/Animals/AnimalsPage.tsx
+++ b/frontend/src/pages/Animals/AnimalsPage.tsx
@@ -1,6 +1,7 @@
 // Animals page — main page component for listing, creating, editing, and deleting animals
 import { useState, useEffect } from 'react';
 import { getAll, getFavoriteAnimals,  type AnimalFilters } from '../../services/animalService';
+import { getUserAdoptionRequests } from '../../services/adoptionRequestService';
 import type { Animal } from '../../types/Animal';
 import Navbar from '../../components/layout/Navbar';
 import AnimalCard from '../../components/common/AnimalCard';
@@ -10,12 +11,14 @@ import './AnimalsPage.css';
 export default function AnimalsPage() {
   const [animals, setAnimals] = useState<Animal[]>([]);
   const [favoriteIds, setFavoriteIds] = useState<number[]>([]);
+  const [adoptionStatusMap, setAdoptionStatusMap] = useState<Record<number, 'pending' | 'approved'>>({});
   const [selectedAnimal, setSelectedAnimal] = useState<Animal | null>(null);
   const [filters, setFilters] = useState<AnimalFilters>({
     type: '',
     size: '',
     temperament: '',
     vaccinated: undefined,
+    adopted: 0,
     ageMin: undefined,
     ageMax: undefined,
   });
@@ -33,6 +36,30 @@ export default function AnimalsPage() {
   }, []);
 
   useEffect(() => {
+    const fetchAdoptionRequests = async () => {
+      try {
+        const requests = await getUserAdoptionRequests();
+        const statusMap: Record<number, 'pending' | 'approved'> = {};
+        for (const req of requests) {
+          if (req.status === 'pending' || req.status === 'approved') {
+            if (!statusMap[req.animal_id]) {
+              statusMap[req.animal_id] = req.status;
+            }
+          }
+        }
+        setAdoptionStatusMap(statusMap);
+      } catch {
+        // Not logged in or other error — no adoption statuses to show
+      }
+    };
+    fetchAdoptionRequests();
+  }, []);
+
+  const handleAdoptionRequest = (animalId: number) => {
+    setAdoptionStatusMap((prev) => ({ ...prev, [animalId]: 'pending' }));
+  };
+
+  useEffect(() => {
     const fetchAnimals = async () => {
       try {
         const data = await getAll({
@@ -40,6 +67,7 @@ export default function AnimalsPage() {
           size: filters.size || undefined,
           temperament: filters.temperament || undefined,
           vaccinated: filters.vaccinated,
+          adopted: filters.adopted,
           ageMin: filters.ageMin,
           ageMax: filters.ageMax,
         });
@@ -57,6 +85,7 @@ export default function AnimalsPage() {
     Boolean(filters.size) ||
     Boolean(filters.temperament) ||
     filters.vaccinated !== undefined ||
+    filters.adopted !== 0 ||
     filters.ageMin !== undefined ||
     filters.ageMax !== undefined;
 
@@ -115,6 +144,20 @@ export default function AnimalsPage() {
           </select>
 
           <select
+            value={filters.adopted === undefined ? '' : String(filters.adopted)}
+            onChange={(e) =>
+              setFilters((f) => ({
+                ...f,
+                adopted: e.target.value === '' ? undefined : (Number(e.target.value) as 0 | 1),
+              }))
+            }
+          >
+            <option value="0">Available</option>
+            <option value="1">Adopted</option>
+            <option value="">All</option>
+          </select>
+
+          <select
             value={
               filters.ageMin === 0 && filters.ageMax === 2
                 ? 'young'
@@ -154,6 +197,7 @@ export default function AnimalsPage() {
                   size: '',
                   temperament: '',
                   vaccinated: undefined,
+                  adopted: 0,
                   ageMin: undefined,
                   ageMax: undefined,
                 })
@@ -169,12 +213,14 @@ export default function AnimalsPage() {
         ) : (
           <section className="animals-page__grid" aria-label="Animal cards">
             {animals.map((animal) => (
-              <AnimalCard key={animal.id} animal={animal} onAbout={(a) => setSelectedAnimal(a)} 
+              <AnimalCard key={animal.id} animal={animal} onAbout={(a) => setSelectedAnimal(a)}
               isFavorited={favoriteIds.includes(animal.id)}
               onFavorite={(id) =>{setFavoriteIds((prev) => [...prev, id]);
                 }}
               onFavoriteRemove={(id) => {
                 setFavoriteIds((prev) => prev.filter((favId) => favId !== id));}}
+              adoptionStatus={adoptionStatusMap[animal.id] ?? null}
+              onAdoptionRequest={handleAdoptionRequest}
               />
             ))}
           </section>
@@ -182,7 +228,9 @@ export default function AnimalsPage() {
       </main>
 
       <AnimalModal key={selectedAnimal?.id} animal={selectedAnimal}
-       onClose={() => setSelectedAnimal(null)}/>
+       onClose={() => setSelectedAnimal(null)}
+       onAdopt={handleAdoptionRequest}
+       adoptionStatus={selectedAnimal ? (adoptionStatusMap[selectedAnimal.id] ?? null) : null}/>
     </>
   );
 }

--- a/frontend/src/pages/Match/MatchPage.tsx
+++ b/frontend/src/pages/Match/MatchPage.tsx
@@ -1,6 +1,7 @@
 // Match page — questionnaire and results page for finding best animal matches
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { getMatches } from '../../services/matchService';
+import { getUserAdoptionRequests, createAdoptionRequest } from '../../services/adoptionRequestService';
 import type { QuestionnaireAnswers, AnimalMatch } from '../../types/Match';
 import Navbar from '../../components/layout/Navbar';
 
@@ -106,6 +107,43 @@ export default function MatchPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [results, setResults] = useState<AnimalMatch[] | null>(null);
+  const [adoptionStatusMap, setAdoptionStatusMap] = useState<Record<number, 'pending' | 'approved'>>({});
+
+  useEffect(() => {
+    if (!results) return;
+    const fetchAdoptionRequests = async () => {
+      try {
+        const requests = await getUserAdoptionRequests();
+        const statusMap: Record<number, 'pending' | 'approved'> = {};
+        for (const req of requests) {
+          if (req.status === 'pending' || req.status === 'approved') {
+            if (!statusMap[req.animal_id]) {
+              statusMap[req.animal_id] = req.status;
+            }
+          }
+        }
+        setAdoptionStatusMap(statusMap);
+      } catch {
+        // Not logged in — no statuses to show
+      }
+    };
+    fetchAdoptionRequests();
+  }, [results]);
+
+  const handleAdopt = async (animalId: number) => {
+    try {
+      await createAdoptionRequest(animalId);
+      setAdoptionStatusMap((prev) => ({ ...prev, [animalId]: 'pending' }));
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        if (err.message === "NOT_LOGGED_IN") {
+          alert("Please log in to adopt animals.");
+        } else {
+          alert(err.message);
+        }
+      }
+    }
+  };
 
   const currentQuestion = questions[step];
   const totalSteps = questions.length;
@@ -319,20 +357,19 @@ export default function MatchPage() {
                   </div>
 
                   <button
-                    onClick={() => {
-                      // TODO: Handle adoption
-                    }}
+                    onClick={() => handleAdopt(match.id)}
+                    disabled={adoptionStatusMap[match.id] === 'pending'}
                     style={{
                       padding: '10px 20px',
                       fontSize: '16px',
-                      cursor: 'pointer',
-                      backgroundColor: '#ff9800',
-                      color: 'white',
+                      cursor: adoptionStatusMap[match.id] === 'pending' ? 'not-allowed' : 'pointer',
+                      backgroundColor: adoptionStatusMap[match.id] === 'pending' ? '#ccc' : '#ff9800',
+                      color: adoptionStatusMap[match.id] === 'pending' ? '#777' : 'white',
                       border: 'none',
                       borderRadius: '4px',
                     }}
                   >
-                    Adopt Me 🐾
+                    {adoptionStatusMap[match.id] === 'pending' ? 'Request Pending' : 'Adopt Me 🐾'}
                   </button>
                 </div>
               );

--- a/frontend/src/pages/Profile/ProfilePage.css
+++ b/frontend/src/pages/Profile/ProfilePage.css
@@ -93,6 +93,77 @@
   font-weight: 600;
 }
 
+/* Adoption requests */
+.profile-page__adoption-requests {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.profile-page__adoption-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.profile-page__adoption-card {
+  padding: 20px;
+  background: var(--color-card-bg);
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.profile-page__adoption-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.profile-page__adoption-animal-name {
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: var(--color-warm-dark);
+}
+
+.profile-page__adoption-status {
+  border-radius: 999px;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.profile-page__adoption-status--pending {
+  color: #92400e;
+  background: #fef3c7;
+}
+
+.profile-page__adoption-status--approved {
+  color: #065f46;
+  background: #d1fae5;
+}
+
+.profile-page__adoption-status--rejected {
+  color: #991b1b;
+  background: #fee2e2;
+}
+
+.profile-page__adoption-status--cancelled {
+  color: #6b7280;
+  background: #f3f4f6;
+}
+
+.profile-page__adoption-card-details {
+  display: flex;
+  gap: 16px;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
 /* Loading and error states */
 .profile-page__loading,
 .profile-page__error {

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -6,7 +6,9 @@ import VolunteerLevelCard from '../../components/common/VolunteerLevelCard';
 import AnimalCard from '../../components/common/AnimalCard';
 import AnimalModal from '../../components/common/AnimalModal';
 import { getFavoriteAnimals } from '../../services/animalService';
+import { getUserAdoptionRequests } from '../../services/adoptionRequestService';
 import type {Animal} from '../../types/Animal';
+import type { AdoptionRequest } from '../../types/AdoptionRequest';
 import { getUserProfile, type UserProfile } from '../../services/userService';
 import './ProfilePage.css';
 
@@ -16,6 +18,7 @@ function ProfilePage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
   const [favoriteAnimals, setFavoriteAnimals] = useState<Animal[]>([]);
+  const [adoptionRequests, setAdoptionRequests] = useState<AdoptionRequest[]>([]);
   const [selectedAnimal, setSelectedAnimal] = useState<Animal | null>(null);
 
   useEffect(() => {
@@ -50,7 +53,18 @@ function ProfilePage() {
     }
   };
     fetchFavorites();
-    
+  }, []);
+
+  useEffect(() => {
+    const fetchAdoptionRequests = async () => {
+      try {
+        const requests = await getUserAdoptionRequests();
+        setAdoptionRequests(requests);
+      } catch {
+        // Not logged in or error
+      }
+    };
+    fetchAdoptionRequests();
   }, []);
 
   if (isLoading) {
@@ -113,9 +127,37 @@ function ProfilePage() {
             </div>
           </section>
 
+          <section className="profile-page__adoption-requests">
+            <header className="animals-page__header">
+              <h1>Adoption Requests</h1>
+              <p>{adoptionRequests.length} request{adoptionRequests.length !== 1 ? 's' : ''}</p>
+            </header>
+
+            {adoptionRequests.length === 0 ? (
+              <p className="animals-page__empty">No adoption requests yet. Browse animals and click "Adopt Me" to get started.</p>
+            ) : (
+              <div className="profile-page__adoption-grid">
+                {adoptionRequests.map((req) => (
+                  <div key={req.id} className="profile-page__adoption-card">
+                    <div className="profile-page__adoption-card-header">
+                      <span className="profile-page__adoption-animal-name">{req.animal_name}</span>
+                      <span className={`profile-page__adoption-status profile-page__adoption-status--${req.status}`}>
+                        {req.status}
+                      </span>
+                    </div>
+                    <div className="profile-page__adoption-card-details">
+                      <span>Type: {req.animal_type}</span>
+                      <span>Submitted: {new Date(req.created_at).toLocaleDateString()}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
           <header className="animals-page__header">
           <h1>Favorite animals</h1>
-          <p>{favoriteAnimals.length} animals are favorited</p>         
+          <p>{favoriteAnimals.length} animals are favorited</p>
         </header>
 
         {favoriteAnimals.length === 0 ? (

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -164,13 +164,19 @@ function ProfilePage() {
           <p className="animals-page__empty"> Add an animal to favorites to see them here.</p>
         ) : (
           <section className="animals-page__grid" aria-label="Animal cards">
-            {favoriteAnimals.map((animal) => (
-              <AnimalCard key={animal.id} animal={animal} onAbout={(a) => setSelectedAnimal(a)} 
-              isFavorited={favoriteAnimals.includes(animal)}
-              onFavorite={() =>{setFavoriteAnimals((prev) => [...prev, animal]);}}
-              onFavoriteRemove={() => {setFavoriteAnimals((prev) => prev.filter((favId) => favId !== animal));}}
-              />
-            ))}
+            {favoriteAnimals.map((animal) => {
+              const adoptionStatus = adoptionRequests
+                .filter(r => r.animal_id === animal.id && (r.status === 'pending' || r.status === 'approved'))
+                .map(r => r.status as 'pending' | 'approved')[0] ?? null;
+              return (
+                <AnimalCard key={animal.id} animal={animal} onAbout={(a) => setSelectedAnimal(a)}
+                isFavorited={favoriteAnimals.includes(animal)}
+                onFavorite={() =>{setFavoriteAnimals((prev) => [...prev, animal]);}}
+                onFavoriteRemove={() => {setFavoriteAnimals((prev) => prev.filter((favId) => favId !== animal));}}
+                adoptionStatus={adoptionStatus}
+                />
+              );
+            })}
           </section>
         )}
         </div>

--- a/frontend/src/services/adoptionRequestService.ts
+++ b/frontend/src/services/adoptionRequestService.ts
@@ -1,0 +1,69 @@
+import api from './api';
+import axios from 'axios';
+import type { AdoptionRequest } from '../types/AdoptionRequest';
+
+export const createAdoptionRequest = async (animalId: number): Promise<AdoptionRequest> => {
+  try {
+    const response = await api.post<AdoptionRequest>('/api/adoption-requests', { animal_id: animalId });
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) throw new Error('NOT_LOGGED_IN');
+      if (error.response?.data?.error) throw new Error(error.response.data.error);
+    }
+    throw error;
+  }
+};
+
+export const getUserAdoptionRequests = async (): Promise<AdoptionRequest[]> => {
+  try {
+    const response = await api.get<{ adoptionRequests: AdoptionRequest[] }>('/api/adoption-requests');
+    return response.data.adoptionRequests;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) throw new Error('NOT_LOGGED_IN');
+    }
+    throw error;
+  }
+};
+
+export const getAdminAdoptionRequests = async (): Promise<AdoptionRequest[]> => {
+  try {
+    const response = await api.get<{ adoptionRequests: AdoptionRequest[] }>('/api/admin/adoption-requests');
+    return response.data.adoptionRequests;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) throw new Error('NOT_LOGGED_IN');
+      if (error.response?.status === 403) throw new Error('USER_NOT_ADMIN');
+    }
+    throw error;
+  }
+};
+
+export const approveAdoptionRequest = async (id: number): Promise<AdoptionRequest> => {
+  try {
+    const response = await api.post<AdoptionRequest>('/api/admin/approveAdoption', { id });
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) throw new Error('NOT_LOGGED_IN');
+      if (error.response?.status === 403) throw new Error('USER_NOT_ADMIN');
+      if (error.response?.data?.error) throw new Error(error.response.data.error);
+    }
+    throw error;
+  }
+};
+
+export const rejectAdoptionRequest = async (id: number): Promise<AdoptionRequest> => {
+  try {
+    const response = await api.post<AdoptionRequest>('/api/admin/rejectAdoption', { id });
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) throw new Error('NOT_LOGGED_IN');
+      if (error.response?.status === 403) throw new Error('USER_NOT_ADMIN');
+      if (error.response?.data?.error) throw new Error(error.response.data.error);
+    }
+    throw error;
+  }
+};

--- a/frontend/src/types/AdoptionRequest.ts
+++ b/frontend/src/types/AdoptionRequest.ts
@@ -1,0 +1,10 @@
+export interface AdoptionRequest {
+    id: number;
+    user_id: number;
+    animal_id: number;
+    animal_name: string;
+    animal_type: string;
+    user_name: string;
+    status: 'pending' | 'approved' | 'rejected' | 'cancelled';
+    created_at: string;
+}


### PR DESCRIPTION
### Description

Added animal adoption request workflow: users can submit adoption requests, and admins can approve or reject them from the admin panel.

### Changes

#### Backend
- New adoption_requests table and SQLAlchemy model
- Controller with create, list, approve, reject logic (auto-cancels other pending requests on approval)
- User endpoints: POST/GET /api/adoption-requests
- Admin endpoints: GET /api/admin/adoption-requests, POST /api/admin/approveAdoption, POST /api/admin/rejectAdoption

#### Frontend

- "Adopt Me" button on animal cards and modal (hidden for adopted animals, disabled when request pending)
- Wired the existing placeholder adopt button on the match results page
- Adoption requests section on the profile page with color-coded status badges
- New admin page for reviewing and approving/rejecting requests
- Dashboard shortcut card for adoption management
- Added "Available / Adopted / All" filter on the animals page



Closes https://github.com/s7eamy/k674-gyvunu-prieglaudos-sistema/issues/86