### PR TITLE
feat/leaderboard

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -66,6 +66,8 @@ def create_app():
     app.register_blueprint(post_bp, url_prefix='/api/posts')
     from app.routes.subscription_routes import subscription_bp
     app.register_blueprint(subscription_bp, url_prefix='/api/subscriptions')
+    from app.routes.leaderboard_routes import leaderboard_bp
+    app.register_blueprint(leaderboard_bp, url_prefix='/api/leaderboard')
 
     # Import all models so db.create_all() picks them up
     from app.models import animal, donation, user, volunteer_registration, merchandise, post, adoption_request, subscription # noqa: F401

--- a/backend/app/controllers/user_controller.py
+++ b/backend/app/controllers/user_controller.py
@@ -14,6 +14,17 @@ def get_all_users():
 
     return [user.to_dict() for user in allUsers]
 
+def get_leaderboard_users():
+    """
+    Get data of top 5 users based on vol and donate points
+    """
+    topUsers = User.query.filter(User.role!='admin').order_by((User.volunteer_points*25+User.donation_points).desc()).slice(0,5)
+    
+    if not topUsers:
+        return None, "Couldn't find users"
+
+    return [user.to_dict() for user in topUsers], None
+
 def get_user_by_id(id):
     """
     Get data of user with selected id

--- a/backend/app/routes/leaderboard_routes.py
+++ b/backend/app/routes/leaderboard_routes.py
@@ -1,0 +1,13 @@
+# Leaderboard - Flask blueprint defining API endpoints for /api/leaderboard
+from flask import Blueprint, jsonify
+from app.controllers import user_controller
+
+leaderboard_bp = Blueprint('leaderboard', __name__)
+
+@leaderboard_bp.route('', methods=['GET'])
+def get_all_users():
+    topUsers, error = user_controller.get_leaderboard_users()
+    if error:
+        return jsonify({"error": error}), 404
+
+    return jsonify({"leaderboardUsers": topUsers}), 200

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import AddAnimalPage from './pages/Admin/AddAnimalPage';
 import PostCreationPage from './pages/Admin/PostCreationPage';
 import PostsPage from './pages/Posts/PostsPage';
 import AdminFeaturePlaceholderPage from './pages/Admin/AdminFeaturePlaceholderPage';
+import LeaderboardPage from './pages/Leaderboard/LeaderboardPage';
 
 function App() {
   return (
@@ -34,6 +35,7 @@ function App() {
         <Route path="/admin/post-creation" element={<PostCreationPage />} />
         <Route path="/merchandise" element={<MerchandisePage />} />
         <Route path="/cart" element={<CartPage />} />
+        <Route path="/leaderboard" element={<LeaderboardPage />} />
         <Route path="/admin/add-animal" element={<AddAnimalPage />} />
         <Route
           path="/admin/merchandise"

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -45,6 +45,7 @@ function Navbar() {
   const isDonateActive = location.pathname === '/donate';
   const isMerchandiseActive = location.pathname === '/merchandise';
   const isCartActive = location.pathname === '/cart';
+  const isLeaderboardActive = location.pathname === '/leaderboard';
   const isAdminDashboardActive = location.pathname.startsWith('/admin');
   const isAdminAddAnimalActive = location.pathname === '/admin/add-animal';
   const isAdmin = userRole === 'admin';
@@ -131,6 +132,12 @@ function Navbar() {
                   className={`navbar__link ${isCartActive ? 'is-active' : ''}`}
                 >
                   🛒 Cart
+                </Link>
+                                <Link
+                  to="/leaderboard"
+                  className={`navbar__link ${isLeaderboardActive ? 'is-active' : ''}`}
+                >
+                  🏆 leaderboard
                 </Link>
               </>
             )}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -137,7 +137,7 @@ function Navbar() {
                   to="/leaderboard"
                   className={`navbar__link ${isLeaderboardActive ? 'is-active' : ''}`}
                 >
-                  🏆 leaderboard
+                  🏆 Leaderboard
                 </Link>
               </>
             )}

--- a/frontend/src/pages/Leaderboard/LeaderboardPage.css
+++ b/frontend/src/pages/Leaderboard/LeaderboardPage.css
@@ -1,0 +1,165 @@
+.leaderboard-page {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  flex: 1;
+}
+
+.leaderboard-page__container {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.leaderboard-page__hero-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 60px 64px;
+  position: relative;
+  z-index: 1;
+}
+
+.leaderboard-page__header {
+  background: #2E2116;
+  color: white;
+  padding: 0;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+  height: auto;
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100vw;
+  margin-left: calc(-50vw + 50%);
+}
+
+.leaderboard-page__header::before {
+  content: '';
+  position: absolute;
+  top: -20%;
+  right: -5%;
+  width: 600px;
+  height: 600px;
+  background: rgba(200, 150, 100, 0.15);
+  border-radius: 50%;
+  filter: blur(80px);
+  pointer-events: none;
+}
+
+.leaderboard-page__header::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: #E8856A;
+  width: 100vw;
+  margin-left: calc(-50vw + 50%);
+}
+
+.leaderboard-page__header h1 {
+
+  margin: 0 0 24px 0;
+  color: white;
+  font-size: clamp(3rem, 6vw, 4.5rem);
+  position: relative;
+  z-index: 2;
+  line-height: 1.1;
+  font-family: 'Playfair Display', serif;
+  text-align: center;
+}
+
+.leaderboard-page__header p {
+  margin: 0 0 40px 0;
+  color: #d9d3ce;
+  font-size: 1.05rem;
+  font-weight: 400;
+  line-height: 1.6;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+
+}
+
+/* Table Styling */
+.table-responsive {
+background: var(--white);
+  border-radius: 12px;
+  border: 2px solid #E8856A;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  margin: 2rem auto;
+  min-width: 40%;
+  max-width: 95%;
+}
+
+.leaderboard-page__table {
+  border-collapse: collapse;
+  text-align: left;
+}
+
+.leaderboard-page__table thead {
+  background-color: var(--color-border-light);
+  color: var(--white);
+}
+
+.leaderboard-page__table th {
+  padding: 1rem 1.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+}
+
+.leaderboard-page__table td {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+  color: var(--text-main);
+  text-align: center;
+}
+
+.leaderboard-page__table tbody tr:hover {
+  background-color: #f1f5f9;
+  transition: background 0.2s ease;
+}
+
+.leaderboard-page__rank-cell {
+  color: var(--primary-color);
+  width: 60px;
+  font-weight: bold;
+}
+
+.leaderboard-page__user-cell { 
+  color: black;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: bold;
+}
+
+.leaderboard-page__avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: var(--color-terracotta);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 7;
+  flex-shrink: 0;
+}
+
+@media (max-width: 600px) {
+  .leaderboard-table th, 
+  .leaderboard-table td {
+    padding: 0.75rem 0.5rem;
+    font-size: 0.9rem;
+  }
+}

--- a/frontend/src/pages/Leaderboard/LeaderboardPage.tsx
+++ b/frontend/src/pages/Leaderboard/LeaderboardPage.tsx
@@ -1,0 +1,89 @@
+// Leaderboard page - shows top 5 users by points
+// may be deleted later and code repurposed for landing page
+import { useEffect, useState } from 'react';
+
+import Navbar from '../../components/layout/Navbar';
+import { getLeaderboard } from '../../services/leaderboardService';
+import type { User } from '../../types/User';
+import './LeaderboardPage.css'
+
+export default function PostsPage() {
+  const [leaderboardUsers, setLeaderboard] = useState<User[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  
+
+  useEffect(() => {
+    const fetchLeaderboard = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await getLeaderboard();
+        setLeaderboard(data);
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : 'Failed to load leaderboard';
+        setError(errorMsg);
+        console.error('Fetch leaderboard failed', err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchLeaderboard();
+  }, []);
+
+  return (
+    <>
+      <Navbar />
+
+      <main className="leaderboard-page">
+        <section className="leaderboard-page__hero">
+            <div className="leaderboard-page__hero-content">
+                <header className='leaderboard-page__header'>
+                <h1>🏆Leaderboard🏆</h1>
+                <p>Our most active users</p>
+                </header>
+            </div>
+        </section>
+        {isLoading && <p >Loading leaderboard...</p>}
+
+        {error && <p >Error: {error}</p>}
+
+        {!isLoading && !error && leaderboardUsers.length === 0 && (
+          <p >No users found :(</p>
+        )}
+
+        {!isLoading && !error && leaderboardUsers.length > 0 && (
+      <div className="table-responsive">
+            <table className="leaderboard-page__table">
+              <thead>
+                <tr>
+                  <th>Rank</th>
+                  <th>User</th>
+                  <th>Total Points</th>
+                  <th>Donation Points</th>
+                  <th>Volunteering Points</th>
+                </tr>
+              </thead>
+              <tbody>
+                {leaderboardUsers.map((user, index) => (
+                  <tr key={user.id}>
+                    <td className="leaderboard-page__rank-cell">{['🥇', '🥈', '🥉'][index] || '#'+(index+1)}</td>
+                    <td className="leaderboard-page__user-cell">
+                            <div className="leaderboard-page__avatar">
+                            {user.name.charAt(0).toUpperCase()}
+                            </div>
+                        {user.name}
+                    </td>
+                    <td>{user.donation_points+user.volunteer_points*25}</td>
+                    <td>{user.donation_points}</td>
+                    <td>{user.volunteer_points*25}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+    </>
+  );
+}

--- a/frontend/src/services/leaderboardService.ts
+++ b/frontend/src/services/leaderboardService.ts
@@ -1,0 +1,14 @@
+import api from './api';
+import type { User } from '../types/User';
+
+
+export const getLeaderboard = async (): Promise<User[]> => {
+    try{
+        const response = await api.get<{ leaderboardUsers: User[] }>("/api/leaderboard", {});
+        return response.data.leaderboardUsers;
+    }
+        catch (error) {
+        console.error("Failure", error);
+        throw error;
+        }     
+};


### PR DESCRIPTION
added leaderboard page that can be accessed by guests and logged in users

formula for total points: (donation_points+25*volunteer_points)

page could be replaced by a leaderboard component that is placed in  other pages

for future: username letter for avatar can later be replaced by a users profile picture

closes #89 