### PR TITLE
feat/about-animal-update

### DIFF
--- a/backend/app/controllers/animal_controller.py
+++ b/backend/app/controllers/animal_controller.py
@@ -63,7 +63,7 @@ def add_animal(data, files):
     """
     Add a new animal to the system.
     Required fields: name, type, breed, size, age, vaccinated, temperament
-    Optional fields: description
+    Optional fields: description, description_lt
     Returns (animal_dict, None) on success or (None, error_message) on failure.
     """
     # Validate required fields
@@ -98,6 +98,7 @@ def add_animal(data, files):
         vaccinated=vaccinated,
         temperament=data['temperament'],
         description=data.get('description', ''),
+        description_lt=data.get('description_lt', ''),
         adopted=0  # New animals are available by default
     )
     

--- a/backend/app/models/animal.py
+++ b/backend/app/models/animal.py
@@ -15,6 +15,7 @@ class Animal(db.Model):
     vaccinated = db.Column(db.Integer, default=0)  # 0 = false, 1 = true
     temperament = db.Column(db.Text)  # calm, energetic, friendly
     description = db.Column(db.Text)
+    description_lt = db.Column(db.Text) #lt translation
     adopted = db.Column(db.Integer, default=0)  # 0 = available, 1 = adopted
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     images = db.relationship('AnimalImage', backref='animal', cascade="all, delete-orphan")
@@ -31,6 +32,7 @@ class Animal(db.Model):
             'vaccinated': bool(self.vaccinated),
             'temperament': self.temperament,
             'description': self.description,
+            'description_lt': self.description_lt,
             'adopted': bool(self.adopted),
             'created_at': self.created_at.isoformat() if self.created_at else None,
             "images": [image.to_dict() for image in self.images]

--- a/backend/seed_animals.py
+++ b/backend/seed_animals.py
@@ -26,7 +26,7 @@ REGULAR_USER_DONATION_POINTS = 100
 IMAGE_BASE_PATH = "frontend/public/images/animals"
 IMAGE_BASE_URL = "/images/animals"
 
-_ANIMAL_MODEL_FIELDS = {"name", "type", "breed", "size", "age", "vaccinated", "temperament", "description", "adopted"}
+_ANIMAL_MODEL_FIELDS = {"name", "type", "breed", "size", "age", "vaccinated", "temperament", "description", "description_lt", "adopted"}
 
 # 3 cats, 4 dogs, 1 rabbit — 7 of 8 have images (87.5% ≈ 80%)
 SEED_ANIMALS = [
@@ -39,7 +39,8 @@ SEED_ANIMALS = [
         "age": 2,
         "vaccinated": 1,
         "temperament": "friendly",
-        "description": "Curious and affectionate, loves window naps and gentle playtime.",
+        "description": "Curious and affectionate, loves window naps and gentle playtime. Vaccinated, neutered.",
+        "description_lt": "Smalsi ir meili, mėgsta miegoti prie langų ir švelniai žaisti. Vakcinuota, kastruota.",
         "adopted": 0,
         "image_filename": "luna.jpg",
         "image_alt": "Luna the Domestic Shorthair cat",
@@ -52,7 +53,8 @@ SEED_ANIMALS = [
         "age": 6,
         "vaccinated": 1,
         "temperament": "calm",
-        "description": "Independent but sweet, enjoys quiet evenings by the fireplace.",
+        "description": "Independent but sweet, enjoys quiet evenings by the fireplace. Vaccinated, neutered.",
+        "description_lt": "Nepriklausomas, bet meilus, mėgsta ramius vakarus prie židinio.  Vakcinuotas, kastruotas.",
         "adopted": 0,
         "image_filename": "oliver.jpg",
         "image_alt": "Oliver the British Shorthair cat",
@@ -65,7 +67,8 @@ SEED_ANIMALS = [
         "age": 1,
         "vaccinated": 1,
         "temperament": "energetic",
-        "description": "Playful chatterbox who loves interactive toys.",
+        "description": "Playful chatterbox who loves interactive toys. Vaccinated, neutered.",
+        "description_lt": "Žaisminga, plepi, mėgsta interaktyvius žaislus. Vakcinuota, kastruota.",
         "adopted": 0,
         "image_filename": None,
         "image_alt": None,
@@ -79,7 +82,8 @@ SEED_ANIMALS = [
         "age": 3,
         "vaccinated": 1,
         "temperament": "friendly",
-        "description": "Happy-go-lucky family dog who loves fetch.",
+        "description": "Happy-go-lucky family dog who loves fetch. Vaccinated, neutered.",
+        "description_lt": "linksmas šuo, tinkamas šeimai, mėgsta atnešti numestus daiktus. Vakcinuotas, kastruotas.",
         "adopted": 0,
         "image_filename": "buddy.jpg",
         "image_alt": "Buddy the Labrador Retriever",
@@ -92,7 +96,8 @@ SEED_ANIMALS = [
         "age": 4,
         "vaccinated": 1,
         "temperament": "energetic",
-        "description": "Smart and active, thrives with training and regular play.",
+        "description": "Smart and active, thrives with training and regular play. Vaccinated, neutered.",
+        "description_lt": "Protingas ir aktyvus, klesti dresūros ir reguliaraus žaidimo metu. Vakcinuotas, kastruotas.",
         "adopted": 0,
         "image_filename": "max.jpg",
         "image_alt": "Max the German Shepherd",
@@ -105,7 +110,8 @@ SEED_ANIMALS = [
         "age": 2,
         "vaccinated": 1,
         "temperament": "friendly",
-        "description": "Nose-led explorer with a cheerful and sociable personality.",
+        "description": "Nose-led explorer with a cheerful and sociable personality. Vaccinated, neutered.",
+        "description_lt": "Tyrinėtoja, pasižymi linksmu ir draugišku charakteriu. Vakcinuota, kastruota.",
         "adopted": 0,
         "image_filename": "daisy.jpg",
         "image_alt": "Daisy the Beagle",
@@ -118,7 +124,8 @@ SEED_ANIMALS = [
         "age": 5,
         "vaccinated": 0,
         "temperament": "energetic",
-        "description": "Goofy and athletic, loves outdoor adventures.",
+        "description": "Goofy and athletic, loves outdoor adventures. Not vaccinated or neutered.",
+        "description_lt": "Atletiškas, mėgsta nuotykius gamtoje. Ne vakcinuotas ar kastruotas.",
         "adopted": 0,
         "image_filename": "rocky.jpg",
         "image_alt": "Rocky the Boxer",
@@ -132,7 +139,8 @@ SEED_ANIMALS = [
         "age": 1,
         "vaccinated": 1,
         "temperament": "calm",
-        "description": "Floppy-eared and gentle, enjoys leafy greens and quiet company.",
+        "description": "Floppy-eared and gentle, enjoys leafy greens and quiet company. Vaccinated, neutered.",
+        "description_lt": "Švelnus, mėgsta žalumynus ir ramią draugyją. Vakcinuotas, kastruotas.",
         "adopted": 0,
         "image_filename": "peanut.jpg",
         "image_alt": "Peanut the Holland Lop rabbit",

--- a/frontend/src/components/common/AnimalModal.tsx
+++ b/frontend/src/components/common/AnimalModal.tsx
@@ -22,11 +22,12 @@ const TEMPERAMENT_EMOJI: Record<string, string> = {
 };
 
 function AnimalModal({ animal, onClose, onAdopt, adoptionStatus }: AnimalModalProps) {
-  const { t } = useTranslation('animalModal');
+  const { t, i18n } = useTranslation('animalModal');
   const enumLabel = useEnumLabel();
   const { formatDate } = useFormatters();
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [isLoadingAdopt, setIsLoadingAdopt] = useState(false);
+  const Locale = i18n.language.startsWith('lt') ? 'lt' : 'en';
 
   const handleAdopt = async () => {
     if (!animal || !onAdopt) return;
@@ -188,7 +189,7 @@ function AnimalModal({ animal, onClose, onAdopt, adoptionStatus }: AnimalModalPr
 
           <section className="animal-modal__section">
             <h3>{t('sections.about')}</h3>
-            <p>{animal.description}</p>
+            <p>{Locale === 'en' ? animal.description : animal.description_lt}</p>
           </section>
         </div>
       </div>

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -87,8 +87,10 @@
       "age": "Age (years)",
       "vaccinated": "Vaccinated",
       "temperament": "Temperament",
-      "description": "Description (Optional)",
-      "descriptionPlaceholder": "Add any special notes about this animal…",
+      "description": "English description (Optional)",
+      "descriptionPlaceholder": "Add any special notes (personality, behaviour, health info) about this animal in english…",
+      "description_lt": "Lithuanian description (Optional)",
+      "description_ltPlaceholder": "Add any special notes (personality, behaviour, health info) about this animal in lithuanian…",
       "image": "Image Upload"
     },
     "validation": {
@@ -98,7 +100,9 @@
       "sizeRequired": "Size is required",
       "ageRequired": "Age is required",
       "ageInvalid": "Age must be a valid non-negative number",
-      "temperamentRequired": "Temperament is required"
+      "temperamentRequired": "Temperament is required",
+      "descriptionRequired": "If there is a lithuanian description, english must also be provided",
+      "description_ltRequired": "If there is an english description, lithuanian must also be provied"
     },
     "submit": "Add Animal",
     "submitting": "Adding Animal…",

--- a/frontend/src/i18n/locales/lt/admin.json
+++ b/frontend/src/i18n/locales/lt/admin.json
@@ -91,8 +91,10 @@
       "age": "Amžius (metais)",
       "vaccinated": "Skiepytas",
       "temperament": "Temperamentas",
-      "description": "Aprašymas (neprivaloma)",
-      "descriptionPlaceholder": "Pridėkite specialių pastabų apie šį gyvūną…",
+      "description": "Angliškas aprašymas (neprivaloma)",
+      "descriptionPlaceholder": "Pridėkite specialių pastabų apie šį gyvūną anglų kalba…",
+      "description_lt": "Lietuviškas aprašymas (neprivaloma)",
+      "description_ltPlaceholder": "Pridėkite specialių pastabų apie šį gyvūną lietuvių kalba…",
       "image": "Nuotraukos įkėlimas"
     },
     "validation": {
@@ -102,7 +104,9 @@
       "sizeRequired": "Dydis privalomas",
       "ageRequired": "Amžius privalomas",
       "ageInvalid": "Amžius turi būti galiojantis neneigiamas skaičius",
-      "temperamentRequired": "Temperamentas privalomas"
+      "temperamentRequired": "Temperamentas privalomas",
+      "descriptionRequired": "Jei pateiktas lietuviškas aprašymas, reikia pateikti anglišką",
+      "description_ltRequired": "Jei pateiktas angliškas aprašymas, reikia pateikti lietuvišką"
     },
     "submit": "Pridėti gyvūną",
     "submitting": "Pridedama…",

--- a/frontend/src/pages/Admin/AddAnimalPage.tsx
+++ b/frontend/src/pages/Admin/AddAnimalPage.tsx
@@ -19,6 +19,7 @@ export default function AddAnimalPage() {
     vaccinated: 0,
     temperament: 'calm',
     description: '',
+    description_lt: '',
     images: [] as File[],
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -69,6 +70,14 @@ export default function AddAnimalPage() {
     if (!formData.temperament || formData.temperament === '') {
       newErrors.temperament = t('addAnimal.validation.temperamentRequired');
     }
+     
+    if (formData.description_lt === '' && formData.description !== ''){
+      newErrors.description_lt = t('addAnimal.validation.description_ltRequired');
+    }
+
+    if (formData.description_lt !== '' && formData.description === ''){
+      newErrors.description = t('addAnimal.validation.descriptionRequired');
+    }
 
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
@@ -110,6 +119,7 @@ export default function AddAnimalPage() {
     dataForImages.append('vaccinated', String(formData.vaccinated));
     dataForImages.append('temperament', formData.temperament);
     dataForImages.append('description', formData.description);
+    dataForImages.append('description_lt', formData.description_lt);
 
     if (formData.images && formData.images.length > 0) {
       formData.images.forEach((file) => {
@@ -129,6 +139,7 @@ export default function AddAnimalPage() {
         vaccinated: 0,
         temperament: 'calm',
         description: '',
+        description_lt: '',
         images: [],
       });
     } catch (error: unknown) {
@@ -279,6 +290,20 @@ export default function AddAnimalPage() {
                   rows={4}
                 />
                 {errors.description && <p className="form-error">{errors.description}</p>}
+              </div>
+
+              <div className="form-field">
+                <label htmlFor="description_lt">{t('addAnimal.fields.description_lt')}</label>
+                <textarea
+                  id="description_lt"
+                  name="description_lt"
+                  value={formData.description_lt}
+                  onChange={handleChange}
+                  disabled={isSubmitting}
+                  placeholder={t('addAnimal.fields.description_ltPlaceholder')}
+                  rows={4}
+                />
+                {errors.description_lt && <p className="form-error">{errors.description_lt}</p>}
               </div>
 
               <div className="form-field">

--- a/frontend/src/types/Animal.ts
+++ b/frontend/src/types/Animal.ts
@@ -9,6 +9,7 @@ export interface Animal {
     vaccinated: boolean;  // 0 = false, 1 = true
     temperament: string;  // calm, energetic, friendly
     description: string; 
+    description_lt: string; 
     adopted: boolean;  // 0 = available, 1 = adopted
     created_at: Date; // default = now()
     images?: { url: string; alt_text?: string }[];


### PR DESCRIPTION
added description_lt column to animals table

admins can create an animal with no description, if they choose to descriptions must be written for both languages

admin is asked to provide health history in description

changing languages changes which description is shown to user in animalModal

added description_lt to seed_animals.py

Closes #98 