### PR TITLE
Feat/donation history

### DIFF
--- a/backend/app/controllers/donation_controller.py
+++ b/backend/app/controllers/donation_controller.py
@@ -65,6 +65,13 @@ def get_donor_level(user_id):
     return _build_donor_level(total_points)
 
 
+def get_user_donation_history(user_id):
+    return Donation.query.filter(
+        Donation.user_id == user_id,
+        Donation.payment_status == 'succeeded',
+    ).order_by(Donation.paid_at.desc()).all()
+
+
 def create_donation_payment_intent(data, user_id=None):
     _set_stripe_key()
 

--- a/backend/app/routes/donation_routes.py
+++ b/backend/app/routes/donation_routes.py
@@ -5,6 +5,7 @@ from app.controllers.donation_controller import (
     create_donation_payment_intent,
     finalize_donation_payment,
     get_donor_level,
+    get_user_donation_history,
 )
 
 donation_bp = Blueprint('donation', __name__)
@@ -35,3 +36,11 @@ def finalize_donation_payment_route():
     payment_intent_id = (data.get('paymentIntentId') or '').strip()
     result = finalize_donation_payment(payment_intent_id, user_id=int(user_id) if user_id else None)
     return jsonify(result), 200
+
+
+@donation_bp.route('/history', methods=['GET'])
+@jwt_required()
+def get_donation_history_route():
+    user_id = get_jwt_identity()
+    donations = get_user_donation_history(int(user_id))
+    return jsonify({'donations': [donation.to_dict() for donation in donations]}), 200

--- a/frontend/src/i18n/locales/en/profile.json
+++ b/frontend/src/i18n/locales/en/profile.json
@@ -33,6 +33,14 @@
     "count_other": "{{count}} volunteerings",
     "empty": "No volunteering sessions yet. Go to the volunteering page and make a registration to get started."
   },
+  "donationHistory": {
+    "title": "Donation History",
+    "count_one": "{{count}} donation",
+    "count_other": "{{count}} donations",
+    "empty": "No donations yet. Complete a donation to see your history here.",
+    "paidAt": "Paid on {{date}}",
+    "anonymous": "No message provided"
+  },
   "upload": "Upload photo",
   "remove": "Remove photo"
 }

--- a/frontend/src/i18n/locales/lt/profile.json
+++ b/frontend/src/i18n/locales/lt/profile.json
@@ -39,6 +39,16 @@
     "count_other": "{{count}} savanorystės",
     "empty": "Savanorystės pamainų dar nėra. Eikite į savanorystės puslapį ir užsiregistruokite."
   },
+  "donationHistory": {
+    "title": "Aukojimo istorija",
+    "count_one": "{{count}} auka",
+    "count_few": "{{count}} aukos",
+    "count_many": "{{count}} aukų",
+    "count_other": "{{count}} aukos",
+    "empty": "Dar nėra aukų. Atlikite auką, kad čia pamatytumėte istoriją.",
+    "paidAt": "Apmokėta {{date}}",
+    "anonymous": "Žinutė neparašyta"
+  },
   "upload": "Įkelti nuotrauką",
   "remove": "Pašalinti nuotrauką"
 }

--- a/frontend/src/pages/Profile/ProfilePage.css
+++ b/frontend/src/pages/Profile/ProfilePage.css
@@ -253,6 +253,63 @@
   font-size: 0.9rem;
 }
 
+/* Donation history */
+.profile-page__donation-history {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.profile-page__donation-history-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.profile-page__donation-card {
+  padding: 20px;
+  background: var(--color-card-bg);
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.profile-page__donation-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.profile-page__donation-amount {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--color-warm-dark);
+}
+
+.profile-page__donation-status {
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.profile-page__donation-status--succeeded {
+  color: #065f46;
+  background: #d1fae5;
+}
+
+.profile-page__donation-details {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
 /* Loading and error states */
 .profile-page__loading,
 .profile-page__error {

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -13,9 +13,11 @@ import { getFavoriteAnimals } from '../../services/animalService';
 import { getUserAdoptionRequests } from '../../services/adoptionRequestService';
 import { getUserVolunteerRegistrations } from '../../services/volunteerRegistrationService';
 import { deleteSubscription, getMySubscriptions, type Subscription } from '../../services/subscriptionService';
+import { getDonationHistory } from '../../services/donorService';
 import type { Animal } from '../../types/Animal';
 import type { AdoptionRequest } from '../../types/AdoptionRequest';
 import type { VolunteerRegistration } from '../../types/VolunteerRegistration';
+import type { Donation } from '../../types/Donation';
 import { getUserProfile, uploadAvatar, deleteAvatar, type UserProfile } from '../../services/userService';
 import { useEnumLabel } from '../../i18n/useEnumLabel';
 import { useFormatters } from '../../i18n/formatters';
@@ -32,6 +34,7 @@ function ProfilePage() {
   const [favoriteAnimals, setFavoriteAnimals] = useState<Animal[]>([]);
   const [adoptionRequests, setAdoptionRequests] = useState<AdoptionRequest[]>([]);
   const [volunteerRegistrations, setVolunteerRegistrations] = useState<VolunteerRegistration[]>([]);
+  const [donationHistory, setDonationHistory] = useState<Donation[]>([]);
   const [selectedAnimal, setSelectedAnimal] = useState<Animal | null>(null);
   const [selectedVolunteerRegistration, setSelectedVolunteerRegistration] = useState<VolunteerRegistration | null>(null);
   const [subscription, setSubscription] = useState<Subscription | null>(null);
@@ -107,6 +110,19 @@ function ProfilePage() {
       }
     };
     fetchVolunteerRegistrations();
+  }, []);
+
+  useEffect(() => {
+    const fetchDonationHistory = async () => {
+      try {
+        const response = await getDonationHistory();
+        setDonationHistory(response.donations);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    fetchDonationHistory();
   }, []);
 
   if (isLoading) {
@@ -311,6 +327,36 @@ function ProfilePage() {
                   onAbout={(v) => setSelectedVolunteerRegistration(v)}
                 />
               ))}
+            </div>
+          )}
+
+          <header className="profile-page__animal-header">
+            <h1>{t('donationHistory.title')}</h1>
+            <p>{t('donationHistory.count', { count: donationHistory.length })}</p>
+          </header>
+
+          {donationHistory.length === 0 ? (
+            <p className="animals-page__empty">{t('donationHistory.empty')}</p>
+          ) : (
+            <div className="profile-page__donation-history">
+              <div className="profile-page__donation-history-grid">
+                {donationHistory.map((donation) => (
+                  <div key={donation.id} className="profile-page__donation-card">
+                    <div className="profile-page__donation-card-header">
+                      <span className="profile-page__donation-amount">
+                        {donation.currency.toUpperCase()} {donation.amount.toFixed(2)}
+                      </span>
+                      <span className={`profile-page__donation-status profile-page__donation-status--${donation.payment_status}`}>
+                        {donation.payment_status}
+                      </span>
+                    </div>
+                    <div className="profile-page__donation-details">
+                      <span>{t('donationHistory.paidAt', { date: formatDate(donation.paid_at) })}</span>
+                      <span>{donation.message || t('donationHistory.anonymous')}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
           )}
         </div>

--- a/frontend/src/services/donorService.ts
+++ b/frontend/src/services/donorService.ts
@@ -1,10 +1,15 @@
 import api from './api';
 import type { DonorLevel } from '../types/DonorLevel';
-import type { CreateDonationPaymentIntentRequest, DonationFinalizeResponse, DonationPaymentIntentResponse } from '../types/Donation';
+import type { CreateDonationPaymentIntentRequest, DonationFinalizeResponse, DonationPaymentIntentResponse, Donation } from '../types/Donation';
 
 export const getDonorLevel = async (): Promise<DonorLevel> => {
   const response = await api.get<{ donor_level: DonorLevel }>('/api/donations/level');
   return response.data.donor_level;
+};
+
+export const getDonationHistory = async (): Promise<{ donations: Donation[] }> => {
+  const response = await api.get<{ donations: Donation[] }>('/api/donations/history');
+  return response.data;
 };
 
 export const createDonationPaymentIntent = async (


### PR DESCRIPTION
Added a Donation History section to the user profile page.

Displays only donations with payment_status = 'succeeded'.

Donation entries are sorted by most recent payment date first.

Added empty state message when the user has no donations:

"No donations yet"

Restricted access to authenticated users only (returns 401 for unauthenticated requests).

Anonymous donations without a user_id are excluded from the history.